### PR TITLE
Update gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TOKEN=your-secret-token-here

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,22 @@
 *.njsproj
 *.sln
 *.sw?
+
+# Secrets
+.env
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Go workspace file
+go.work


### PR DESCRIPTION
## Description
Adds an env example file and adds the normal one and the go binaries to the gitignore.

## Related issue
Resolves #16

## How can this be tested?
- Create .env locally. 
- Should not be committed when using `git add .`