### PR TITLE
Add dependabot auto updates for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod" 
+    directory: "/" 
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Description

This adds a Dependabot config which will check every month for new updates of basic go modules.

## Related issue

Resolves #29 