### PR TITLE
Hotfix: Create app directory during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM alpine:latest
 
 RUN apk add --no-cache iputils setpriv dumb-init && rm -rf /root/.cache
 
+RUN mkdir /app
 COPY --from=0 /app/jojo-discord-bot /app/jojo-discord-bot
 COPY ./scripts/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod 755 /app/jojo-discord-bot


### PR DESCRIPTION
## Description
Create app directory during build

## Related issue
No related issue, as it is a hotfix for the latest release.