### PR TITLE
Hotfix: Properly tag Docker images

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/lazybytez/jojo-discord-bot
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge,enable=true,priority=700,prefix=,suffix=,branch=$repo.default_branch
+
       - name: Build and publish images
         uses: docker/build-push-action@v3
         with:
@@ -38,4 +49,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/lazybytez/jojo-discord-bot:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ LABEL maintainer="contact@lazybytez.de"
 # Open Container annotations
 LABEL org.opencontainers.image.title="JOJO Discord Bot"
 LABEL org.opencontainers.image.description="An advanced multi-purpose discord bot"
-LABEL org.opencontainers.image.vendor ="Lazy Bytez"
+LABEL org.opencontainers.image.vendor="Lazy Bytez"
 LABEL org.opencontainers.image.source="https://github.com/lazybytez/jojo-discord-bot"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 


### PR DESCRIPTION
## Description
Properly tag Docker images, as right now they are loosing their tags on cd

## Related issue
No issue because it's a quick hotfix