### PR TITLE
feat(comp): adjust min and max value options

### DIFF
--- a/components/dice/command.go
+++ b/components/dice/command.go
@@ -5,6 +5,12 @@ import (
 	"github.com/lazybytez/jojo-discord-bot/api"
 )
 
+var memberPermissions int64 = discordgo.PermissionSendMessages
+
+var minValueDieSites = float64(2)
+var maxValueDieSites = float64(1000)
+var minValueDice = float64(1)
+var maxValueDice = float64(100)
 var diceCommand = &api.Command{
 	Cmd: &discordgo.ApplicationCommand{
 		Name:                     "dice",
@@ -15,14 +21,16 @@ var diceCommand = &api.Command{
 				Name:        "die-sites-number",
 				Description: "The number of how many sites the die has, default is 6",
 				Type:        discordgo.ApplicationCommandOptionInteger,
-				MinValue:    &minValue,
+				MinValue:    &minValueDieSites,
+				MaxValue:    maxValueDieSites,
 				Required:    false,
 			},
 			{
 				Name:        "number-dice",
 				Description: "How many dice you want to throw, default is 1",
 				Type:        discordgo.ApplicationCommandOptionInteger,
-				MinValue:    &minValue,
+				MinValue:    &minValueDice,
+				MaxValue:    maxValueDice,
 				Required:    false,
 			},
 		},

--- a/components/dice/register_command.go
+++ b/components/dice/register_command.go
@@ -18,9 +18,6 @@ var C = api.Component{
 	},
 }
 
-var minValue = float64(2)
-var memberPermissions int64 = discordgo.PermissionSendMessages
-
 // init initializes the component with its metadata
 func init() {
 	api.RegisterComponent(&C, LoadComponent)


### PR DESCRIPTION
Refs: #38

## Description

It sets max values for the options of the `/dice` command and adjusts the min of the number-dice option.

## Related issue

Improves #38 

## How can this be tested?

You can't use the command with `number-dice` higher than 100 or lower then 1.
You can't use the command with `die-sites-number` higher than 1000 or lower then 2.
