### PR TITLE
Add possibility to retrieve version

### DIFF
--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -1,0 +1,60 @@
+# Continues deployment workflow to automatically
+# build Docker image on tag 
+name: Deploy Edge
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  edge:
+    runs-on: ubuntu-latest
+    environment:
+      name: Staging
+    env:
+      IS_CI: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Docker with buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Login to GitHub packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/lazybytez/jojo-discord-bot
+          tags: |
+            type=edge,branch=develop
+
+      - name: Retrieve commit SHA
+        id: commit_sha
+        run: echo "::set-output name=short::$(git rev-parse --short HEAD)"
+
+      - name: Build and publish images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            app_version=edge
+            build_commit_sha=${{ steps.commit_sha.outputs.short }}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -26,19 +26,20 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_REGISTRY_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
       - name: Login to GitHub packages
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
-
-      - name: Login to DOCR
-        uses: docker/login-action@v2
-        with:
-          registry: registry.digitalocean.com
-          username: ${{ secrets.DO_REGISTRY_TOKEN }}
-          password: ${{ secrets.DO_REGISTRY_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,17 +1,17 @@
 # Continues deployment workflow to automatically
 # build Docker image on tag 
-name: CD
+name: Deploy Release
 
 on:
   push:
-    branches:
-      - 'develop'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
+    environment:
+      name: Production
     env:
       IS_CI: true
     steps:
@@ -33,18 +33,29 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
+      - name: Login to DOCR
+        uses: docker/login-action@v2
+        with:
+          registry: registry.digitalocean.com
+          username: ${{ secrets.DO_REGISTRY_TOKEN }}
+          password: ${{ secrets.DO_REGISTRY_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/lazybytez/jojo-discord-bot
+          images: |
+            ghcr.io/lazybytez/jojo-discord-bot
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=edge,branch=develop
 
-      - name: Build and publish images
+      - name: Retrieve commit SHA
+        id: commit_sha
+        run: echo "::set-output name=short::$(git rev-parse --short HEAD)"
+
+      - name: Build and publish public image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -53,3 +64,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            app_version=${{ github.ref_name }}
+            build_commit_sha=${{ steps.commit_sha.outputs.short }}
+
+      - name: Publish image for production environment
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/lazybytez/jojo-discord-bot:latest
+          dst: |
+            registry.digitalocean.com/lazybytez/jojo-discord-bot:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # First build application
 FROM golang:1.19-alpine
 
+ARG app_version="edge"
+ARG build_commit_sha=""
+
+ENV APP_VERSION=$app_version
+ENV BUILD_COMMIT_SHA=$build_commit_sha
+
 RUN mkdir -p /app
 WORKDIR /app
 
@@ -13,7 +19,7 @@ RUN go mod download && go mod verify
 
 # Copy source and start build
 COPY . .
-RUN go build -v -o /app ./...
+RUN go build -ldflags "-X github.com/lazybytez/jojo-discord-bot/build.Version=${APP_VERSION} -X github.com/lazybytez/jojo-discord-bot/build.CommitSHA=${BUILD_COMMIT_SHA}" -v -o /app ./...
 
 # Throw away last step and put binary in basic alpine image
 FROM alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ run:
 	go run .
 
 # Builds an executable for production usage
+# Build will be tagged as edge and include commit SHA
 .PHONY: build
 build:
-	go build .
+	go build -ldflags "-X github.com/lazybytez/jojo-discord-bot/build.Version=edge -X github.com/lazybytez/jojo-discord-bot/build.CommitSHA=`git rev-parse --short HEAD`" .
 
 # === Quality Assurance ===
 # =========================

--- a/build/version.go
+++ b/build/version.go
@@ -1,0 +1,56 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package build
+
+import "fmt"
+
+// These variables are injected during build time.
+//
+// Version holds the currently running version.
+// This either matches the Git tag on which the build is based
+// or "edge" for any other build.
+//
+// If Version is "edge", the CommitSHA should be populated too.
+// It should always keep the SHA of the commit that was used to build
+// this version.
+
+var (
+	Version   string
+	CommitSHA string
+)
+
+// init handles the case when no values were given during build
+func init() {
+	if Version == "" {
+		Version = "edge"
+	}
+
+	if CommitSHA == "" {
+		CommitSHA = "unknown"
+	}
+}
+
+// ComputeVersionString returns the current version in a displayable format
+func ComputeVersionString() string {
+	if Version == "edge" {
+		return fmt.Sprintf("%s<%s>", Version, CommitSHA)
+	}
+
+	return Version
+}

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,0 +1,23 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package build
+
+type VersionTestSuite struct {
+	suite.Sui
+}

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -18,6 +18,32 @@
 
 package build
 
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
 type VersionTestSuite struct {
-	suite.Sui
+	suite.Suite
+}
+
+func (suite *VersionTestSuite) TestComputeVersionStringWithEdgeVersionAndSHA() {
+	Version = "edge"
+	CommitSHA = "12345543321"
+
+	result := ComputeVersionString()
+
+	suite.Equal("edge<12345543321>", result)
+}
+
+func (suite *VersionTestSuite) TestComputeVersionStringWithTaggedVersion() {
+	Version = "v1.5.3"
+
+	result := ComputeVersionString()
+
+	suite.Equal("v1.5.3", result)
+}
+
+func TestVersion(t *testing.T) {
+	suite.Run(t, new(VersionTestSuite))
 }

--- a/components/statistics/command.go
+++ b/components/statistics/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/dustin/go-humanize"
 	"github.com/lazybytez/jojo-discord-bot/api"
+	"github.com/lazybytez/jojo-discord-bot/build"
 	"io"
 	"os"
 	"runtime"
@@ -134,6 +135,7 @@ func buildStatOutput() string {
 	appendStatLine(w, "Threads: **%s**\n", humanize.Comma(int64(runtime.NumGoroutine())))
 	appendStatLine(w, "Connected Servers: **%v**\n", countMsg)
 	appendStatLine(w, "Cluster ID: **%s**\n", cluster)
+	appendStatLine(w, "Version: **%s**\n", build.ComputeVersionString())
 
 	err = w.Flush()
 	if err != nil {


### PR DESCRIPTION
## Description
Add the possibility to retrieve the currently running version during runtime.
Extend the `/stats` command with version information.

## Related issue
Resolves #103 

## Test Cases
 - Check log of workflow runs from https://github.com/lazybytez/jojo-discord-bot/actions/workflows/deploy_release.yml and ensure that no secrets are leaked!
 - Check that the `/stats` command now (may) include a version information