### PR TITLE
Add bot audit log configuration

### DIFF
--- a/api/entities/audit_log_config.go
+++ b/api/entities/audit_log_config.go
@@ -1,0 +1,123 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package entities
+
+import (
+	"github.com/lazybytez/jojo-discord-bot/api/cache"
+	"gorm.io/gorm"
+	"time"
+)
+
+// AuditLogConfig holds the guild specific configuration for audit logging.
+type AuditLogConfig struct {
+	gorm.Model
+	GuildID   uint64 `gorm:"uniqueIndex;"`
+	Guild     Guild  `gorm:"constraint:OnDelete:CASCADE;"`
+	ChannelId uint64
+	Enabled   bool
+}
+
+// AuditLogConfigEntityManager is the audit log config specific entity manager
+// that allows easy access to audit log configurations.
+type AuditLogConfigEntityManager struct {
+	EntityManager
+
+	cache *cache.Cache[uint64, AuditLogConfig]
+}
+
+// NewAuditLogConfigEntityManager creates a new AuditLogConfigEntityManager.
+func NewAuditLogConfigEntityManager(entityManager EntityManager) *AuditLogConfigEntityManager {
+	alcem := &AuditLogConfigEntityManager{
+		entityManager,
+		cache.New[uint64, AuditLogConfig](10 * time.Minute),
+	}
+
+	err := alcem.cache.EnableAutoCleanup(10 * time.Minute)
+	if nil != err {
+		entityManager.Logger().Err(err, "Failed to initialize periodic cache cleanup task "+
+			"for AuditLogConfig entity manager!")
+	}
+
+	return alcem
+}
+
+// GetByGuildId tries to get a AuditLogConfig by its guild ID.
+// The function uses a cache and first tries to resolve a value from it.
+// If no cache entry is present, a request to the entities will be made.
+// If no AuditLogConfig can be found, the function returns a new empty
+// AuditLogConfig.
+func (alcem *AuditLogConfigEntityManager) GetByGuildId(guildId uint64) (*AuditLogConfig, error) {
+	auditLogConfig, ok := cache.Get(alcem.cache, guildId)
+
+	if ok {
+		return auditLogConfig, nil
+	}
+
+	auditLogConfig = &AuditLogConfig{}
+	queryStr := ColumnGuild + " = ?"
+	err := alcem.DB().GetFirstEntity(auditLogConfig, queryStr, guildId)
+	if nil != err {
+		return auditLogConfig, err
+	}
+
+	cache.Update(alcem.cache, auditLogConfig.GuildID, auditLogConfig)
+
+	return auditLogConfig, nil
+}
+
+// Create saves the passed AuditLogConfig in the database.
+// Use Update or Save to update an already existing AuditLogConfig.
+func (alcem *AuditLogConfigEntityManager) Create(auditLogConfig *AuditLogConfig) error {
+	err := alcem.DB().Create(auditLogConfig)
+	if nil != err {
+		return err
+	}
+
+	// Ensure entity is in cache when just updated
+	cache.Update(alcem.cache, auditLogConfig.GuildID, auditLogConfig)
+
+	return nil
+}
+
+// Save updates the passed Guild in the database.
+// This does a generic update, use Update to do a precise and more performant update
+// of the entity when only updating a single field!
+func (alcem *AuditLogConfigEntityManager) Save(auditLogConfig *AuditLogConfig) error {
+	err := alcem.DB().Save(auditLogConfig)
+	if nil != err {
+		return err
+	}
+
+	// Ensure entity is in cache when just updated
+	cache.Update(alcem.cache, auditLogConfig.GuildID, auditLogConfig)
+
+	return nil
+}
+
+// Update updates the defined field on the entity and saves it in the database.
+func (alcem *AuditLogConfigEntityManager) Update(auditLogConfig *AuditLogConfig, column string, value interface{}) error {
+	err := alcem.DB().UpdateEntity(auditLogConfig, column, value)
+	if nil != err {
+		return err
+	}
+
+	cache.Update(alcem.cache, auditLogConfig.GuildID, auditLogConfig)
+
+	return nil
+}

--- a/api/entities/audit_log_config.go
+++ b/api/entities/audit_log_config.go
@@ -27,9 +27,9 @@ import (
 // AuditLogConfig holds the guild specific configuration for audit logging.
 type AuditLogConfig struct {
 	gorm.Model
-	GuildID   uint64 `gorm:"uniqueIndex;"`
-	Guild     Guild  `gorm:"constraint:OnDelete:CASCADE;"`
-	ChannelId uint64
+	GuildID   uint  `gorm:"uniqueIndex;"`
+	Guild     Guild `gorm:"constraint:OnDelete:CASCADE;"`
+	ChannelId *uint64
 	Enabled   bool
 }
 
@@ -38,14 +38,14 @@ type AuditLogConfig struct {
 type AuditLogConfigEntityManager struct {
 	EntityManager
 
-	cache *cache.Cache[uint64, AuditLogConfig]
+	cache *cache.Cache[uint, AuditLogConfig]
 }
 
 // NewAuditLogConfigEntityManager creates a new AuditLogConfigEntityManager.
 func NewAuditLogConfigEntityManager(entityManager EntityManager) *AuditLogConfigEntityManager {
 	alcem := &AuditLogConfigEntityManager{
 		entityManager,
-		cache.New[uint64, AuditLogConfig](10 * time.Minute),
+		cache.New[uint, AuditLogConfig](10 * time.Minute),
 	}
 
 	err := alcem.cache.EnableAutoCleanup(10 * time.Minute)
@@ -62,7 +62,7 @@ func NewAuditLogConfigEntityManager(entityManager EntityManager) *AuditLogConfig
 // If no cache entry is present, a request to the entities will be made.
 // If no AuditLogConfig can be found, the function returns a new empty
 // AuditLogConfig.
-func (alcem *AuditLogConfigEntityManager) GetByGuildId(guildId uint64) (*AuditLogConfig, error) {
+func (alcem *AuditLogConfigEntityManager) GetByGuildId(guildId uint) (*AuditLogConfig, error) {
 	auditLogConfig, ok := cache.Get(alcem.cache, guildId)
 
 	if ok {

--- a/api/entities/audit_log_config_test.go
+++ b/api/entities/audit_log_config_test.go
@@ -1,0 +1,267 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package entities
+
+import (
+	"fmt"
+	"github.com/lazybytez/jojo-discord-bot/api/cache"
+	"github.com/lazybytez/jojo-discord-bot/test/dbmock"
+	"github.com/lazybytez/jojo-discord-bot/test/entity_manager_mock"
+	"github.com/lazybytez/jojo-discord-bot/test/logmock"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type AuditLogConfigEntityManagerTestSuite struct {
+	suite.Suite
+	dba    *dbmock.DatabaseAccessMock
+	logger *logmock.LoggerMock
+	em     entity_manager_mock.EntityManagerMock
+	gem    *AuditLogConfigEntityManager
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) SetupTest() {
+	dba := &dbmock.DatabaseAccessMock{}
+	logger := &logmock.LoggerMock{}
+
+	suite.dba = dba
+	suite.logger = logger
+	suite.em = entity_manager_mock.EntityManagerMock{}
+	suite.gem = &AuditLogConfigEntityManager{
+		&suite.em,
+		cache.New[uint64, AuditLogConfig](5 * time.Second),
+	}
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestNewAuditLogConfigEntityManager() {
+	testEntityManager := entity_manager_mock.EntityManagerMock{}
+
+	gem := NewAuditLogConfigEntityManager(&testEntityManager)
+
+	suite.NotNil(gem)
+	suite.NotNil(gem.cache)
+	suite.Equal(&testEntityManager, gem.EntityManager)
+
+	gem.cache.DisableAutoCleanup()
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildID() {
+	testGuildId := uint64(12345123451234512345)
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On(
+		"GetFirstEntity",
+		mock.AnythingOfType(reflect.TypeOf(&AuditLogConfig{}).Name()),
+		[]interface{}{ColumnGuildId + " = ?", testGuildId},
+	).Run(func(args mock.Arguments) {
+		switch v := args.Get(0).(type) {
+		case *AuditLogConfig:
+			v.GuildID = testGuildId
+		}
+	}).Return(nil).Once()
+
+	result, err := suite.gem.GetByGuildId(testGuildId)
+
+	suite.dba.AssertExpectations(suite.T())
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.Equal(testGuildId, result.GuildID)
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.True(ok)
+	suite.Equal(result, cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithCache() {
+	testGuildId := uint64(12345123451234512345)
+
+	testAuditLogConfig := &AuditLogConfig{
+		GuildID: testGuildId,
+	}
+
+	cache.Update(suite.gem.cache, testGuildId, testAuditLogConfig)
+
+	// Do not expect call of GetFirstEntity or DB calls
+	// When GetFirstEntity is called, test will fail as call is unexpected
+
+	result, err := suite.gem.GetByGuildId(testGuildId)
+
+	suite.dba.AssertExpectations(suite.T())
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.Equal(testGuildId, result.GuildID)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithError() {
+	testGuildId := uint64(12345123451234512345)
+
+	expectedError := fmt.Errorf("something bad happened during database read")
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On(
+		"GetFirstEntity",
+		mock.AnythingOfType(reflect.TypeOf(&AuditLogConfig{}).Name()),
+		[]interface{}{ColumnGuildId + " = ?", testGuildId},
+	).Return(expectedError).Once()
+
+	result, err := suite.gem.GetByGuildId(testGuildId)
+
+	suite.dba.AssertExpectations(suite.T())
+	suite.Error(err)
+	suite.NotNil(result)
+	suite.Equal(*result, AuditLogConfig{})
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.False(ok)
+	suite.Nil(cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestCreate() {
+	testGuildId := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildId,
+	}
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("Create", &testAuditLogConfig).Return(nil).Once()
+
+	err := suite.gem.Create(&testAuditLogConfig)
+
+	suite.NoError(err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.True(ok)
+	suite.Equal(&testAuditLogConfig, cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestCreateWithError() {
+	testGuildId := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildId,
+	}
+
+	expectedErr := fmt.Errorf("something happened during update")
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("Create", &testAuditLogConfig).Return(expectedErr).Once()
+
+	err := suite.gem.Create(&testAuditLogConfig)
+
+	suite.Error(err)
+	suite.Equal(expectedErr, err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.False(ok)
+	suite.Nil(cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestSave() {
+	testGuildId := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildId,
+	}
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("Save", &testAuditLogConfig).Return(nil).Once()
+
+	err := suite.gem.Save(&testAuditLogConfig)
+
+	suite.NoError(err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.True(ok)
+	suite.Equal(&testAuditLogConfig, cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestSaveWithError() {
+	testGuildID := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildID,
+	}
+
+	expectedErr := fmt.Errorf("something happened during update")
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("Save", &testAuditLogConfig).Return(expectedErr).Once()
+
+	err := suite.gem.Save(&testAuditLogConfig)
+
+	suite.Error(err)
+	suite.Equal(expectedErr, err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildID)
+	suite.False(ok)
+	suite.Nil(cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestUpdate() {
+	testGuildId := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildId,
+	}
+	testColumn := "some_column"
+	testValue := "some_value"
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("UpdateEntity", &testAuditLogConfig, testColumn, testValue).Return(nil).Once()
+
+	err := suite.gem.Update(&testAuditLogConfig, testColumn, testValue)
+
+	suite.NoError(err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.True(ok)
+	suite.Equal(&testAuditLogConfig, cachedRegisteredComponent)
+}
+
+func (suite *AuditLogConfigEntityManagerTestSuite) TestUpdateWithError() {
+	testGuildId := uint64(12345123451234512345)
+	testAuditLogConfig := AuditLogConfig{
+		GuildID: testGuildId,
+	}
+	testColumn := "some_column"
+	testValue := "some_value"
+
+	expectedErr := fmt.Errorf("something happened during update")
+
+	suite.em.On("DB").Return(suite.dba)
+	suite.dba.On("UpdateEntity", &testAuditLogConfig, testColumn, testValue).Return(expectedErr).Once()
+
+	err := suite.gem.Update(&testAuditLogConfig, testColumn, testValue)
+
+	suite.Error(err)
+	suite.Equal(expectedErr, err)
+	suite.dba.AssertExpectations(suite.T())
+
+	cachedRegisteredComponent, ok := cache.Get(suite.gem.cache, testGuildId)
+	suite.False(ok)
+	suite.Nil(cachedRegisteredComponent)
+}
+
+func TestAuditLogConfigEntityManager(t *testing.T) {
+	suite.Run(t, new(AuditLogConfigEntityManagerTestSuite))
+}

--- a/api/entities/audit_log_config_test.go
+++ b/api/entities/audit_log_config_test.go
@@ -48,7 +48,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) SetupTest() {
 	suite.em = entity_manager_mock.EntityManagerMock{}
 	suite.gem = &AuditLogConfigEntityManager{
 		&suite.em,
-		cache.New[uint64, AuditLogConfig](5 * time.Second),
+		cache.New[uint, AuditLogConfig](5 * time.Second),
 	}
 }
 
@@ -65,7 +65,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestNewAuditLogConfigEntityMa
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildID() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 
 	suite.em.On("DB").Return(suite.dba)
 	suite.dba.On(
@@ -92,7 +92,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildID() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithCache() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 
 	testAuditLogConfig := &AuditLogConfig{
 		GuildID: testGuildId,
@@ -112,7 +112,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithCache() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithError() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 
 	expectedError := fmt.Errorf("something bad happened during database read")
 
@@ -136,7 +136,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestGetByGuildIDWithError() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestCreate() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildId,
 	}
@@ -155,7 +155,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestCreate() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestCreateWithError() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildId,
 	}
@@ -177,7 +177,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestCreateWithError() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestSave() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildId,
 	}
@@ -196,7 +196,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestSave() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestSaveWithError() {
-	testGuildID := uint64(12345123451234512345)
+	testGuildID := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildID,
 	}
@@ -218,7 +218,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestSaveWithError() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestUpdate() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildId,
 	}
@@ -239,7 +239,7 @@ func (suite *AuditLogConfigEntityManagerTestSuite) TestUpdate() {
 }
 
 func (suite *AuditLogConfigEntityManagerTestSuite) TestUpdateWithError() {
-	testGuildId := uint64(12345123451234512345)
+	testGuildId := uint(123123)
 	testAuditLogConfig := AuditLogConfig{
 		GuildID: testGuildId,
 	}

--- a/api/entities/guild_component_status.go
+++ b/api/entities/guild_component_status.go
@@ -38,7 +38,7 @@ type GuildComponentStatus struct {
 	Enabled     bool
 }
 
-// GuildComponentStatusEntityManager is the GuildCom specific entity manager
+// GuildComponentStatusEntityManager is the guild component specific entity manager
 // that allows easy access to guilds in the entities.
 type GuildComponentStatusEntityManager struct {
 	EntityManager

--- a/api/entity_manager.go
+++ b/api/entity_manager.go
@@ -32,6 +32,7 @@ var defaultEntities = []interface{}{
 	&entities.RegisteredComponent{},
 	&entities.GlobalComponentStatus{},
 	&entities.GuildComponentStatus{},
+	&entities.AuditLogConfig{},
 }
 
 // EntityManager is a struct embedded by GormDatabaseAccessor
@@ -44,6 +45,7 @@ type EntityManager struct {
 	globalComponentStatusEntityManager GlobalComponentStatusEntityManager
 	registeredComponentEntityManager   RegisteredComponentEntityManager
 	guildComponentStatusEntityManager  GuildComponentStatusEntityManager
+	auditLogConfigEntityManager        AuditLogConfigEntityManager
 }
 
 // entityManager is the internal database.GormDatabaseAccess instance

--- a/api/entity_managers.go
+++ b/api/entity_managers.go
@@ -157,3 +157,34 @@ func (em *EntityManager) GuildComponentStatus() GuildComponentStatusEntityManage
 
 	return em.guildComponentStatusEntityManager
 }
+
+// AuditLogConfigEntityManager is an entity manager
+// that provides functionality for entities.AuditLogConfig CRUD operations.
+type AuditLogConfigEntityManager interface {
+	// GetByGuildId tries to get a AuditLogConfig by its guild ID.
+	// The function uses a cache and first tries to resolve a value from it.
+	// If no cache entry is present, a request to the entities will be made.
+	// If no AuditLogConfig can be found, the function returns a new empty
+	// AuditLogConfig.
+	GetByGuildId(guildId uint64) (*entities.AuditLogConfig, error)
+
+	// Create saves the passed Guild in the db.
+	// Use Update or Save to update an already existing Guild.
+	Create(auditLogConfig *entities.AuditLogConfig) error
+	// Save updates the passed Guild in the db.
+	// This does a generic update, use Update to do a precise and more performant update
+	// of the entity when only updating a single field!
+	Save(auditLogConfig *entities.AuditLogConfig) error
+	// Update updates the defined field on the entity and saves it in the db.
+	Update(auditLogConfig *entities.AuditLogConfig, column string, value interface{}) error
+}
+
+// AuditLogConfig returns the AuditLogConfigEntityManager that is currently active,
+// which can be used to do entities.AuditLogConfig specific entities actions.
+func (em *EntityManager) AuditLogConfig() AuditLogConfigEntityManager {
+	if nil == em.auditLogConfigEntityManager {
+		em.auditLogConfigEntityManager = entities.NewAuditLogConfigEntityManager(em)
+	}
+
+	return em.auditLogConfigEntityManager
+}

--- a/api/entity_managers.go
+++ b/api/entity_managers.go
@@ -166,7 +166,7 @@ type AuditLogConfigEntityManager interface {
 	// If no cache entry is present, a request to the entities will be made.
 	// If no AuditLogConfig can be found, the function returns a new empty
 	// AuditLogConfig.
-	GetByGuildId(guildId uint64) (*entities.AuditLogConfig, error)
+	GetByGuildId(guildId uint) (*entities.AuditLogConfig, error)
 
 	// Create saves the passed Guild in the db.
 	// Use Update or Save to update an already existing Guild.

--- a/api/entity_managers_test.go
+++ b/api/entity_managers_test.go
@@ -134,6 +134,29 @@ func (suite *EntityManagersTestSuite) TestGetGuildComponentStatusEntityManagerWi
 	suite.Equal(result, result2)
 }
 
+func (suite *EntityManagersTestSuite) TestGetAuditLogConfigEntityManagerWithExistingAuditLogConfigEntityManager() {
+	auditLogEntityManager := &entities.AuditLogConfigEntityManager{}
+
+	suite.em.auditLogConfigEntityManager = auditLogEntityManager
+
+	result := suite.em.AuditLogConfig()
+
+	suite.NotNil(result)
+	suite.Equal(auditLogEntityManager, result)
+}
+
+func (suite *EntityManagersTestSuite) TestGetAuditLogConfigEntityManagerWithNoExistingAuditLogConfigEntityManager() {
+	result := suite.em.AuditLogConfig()
+	result2 := suite.em.AuditLogConfig()
+
+	// First call
+	suite.NotNil(result)
+	suite.IsType(&entities.AuditLogConfigEntityManager{}, result)
+
+	// Consecutive calls
+	suite.Equal(result, result2)
+}
+
 func TestEntityManagers(t *testing.T) {
 	suite.Run(t, new(EntityManagersTestSuite))
 }

--- a/api/slash_commands/response.go
+++ b/api/slash_commands/response.go
@@ -19,8 +19,14 @@
 package slash_commands
 
 import (
+	"fmt"
 	"github.com/bwmarrin/discordgo"
 	"github.com/lazybytez/jojo-discord-bot/api"
+)
+
+const (
+	GenericErrorResponseEmbedName  = ":x: Damn, something went wrong!"
+	GenericErrorResponseEmbedValue = "Something unexpected happened while processing the command!"
 )
 
 // GenerateInteractionResponseTemplate creates a prefilled discordgo.InteractionResponseData
@@ -86,6 +92,66 @@ func Respond(
 	if nil != err {
 		c.Logger().Err(err, "Failed to deliver interaction response on slash-command!")
 	}
+}
+
+// RespondWithSimpleEmbedMessage fills the passed discordgo.InteractionResponseData
+// with an embed that contains a single field with a name and value.
+//
+// The prepared interaction response will be sent.
+func RespondWithSimpleEmbedMessage(
+	c *api.Component,
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+	header string,
+	message string,
+) {
+	embeds := []*discordgo.MessageEmbedField{
+		{
+			Name:  header,
+			Value: message,
+		},
+	}
+
+	resp.Embeds[0].Fields = embeds
+
+	Respond(c, s, i, resp)
+}
+
+// RespondWithGenericErrorMessage fills the passed discordgo.InteractionResponseData
+// with a generic error message as content.
+//
+// The prepared interaction response will be sent.
+func RespondWithGenericErrorMessage(
+	c *api.Component,
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+) {
+	embeds := []*discordgo.MessageEmbedField{
+		{
+			Name:  GenericErrorResponseEmbedName,
+			Value: GenericErrorResponseEmbedValue,
+		},
+	}
+
+	resp.Embeds[0].Fields = embeds
+
+	Respond(c, s, i, resp)
+}
+
+// RespondWithCommandIsGuildOnly responds with a message stating that the executed
+// command is only available on guilds.
+func RespondWithCommandIsGuildOnly(
+	c *api.Component,
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	commandName string,
+) {
+	resp := GenerateInteractionResponseTemplate("Stop!",
+		fmt.Sprintf("The `%s` command and its subcommand cannot be executed in DMs!", commandName))
+
+	Respond(c, s, i, resp)
 }
 
 // EditResponse edits the passed interactions original response with

--- a/core_components/bot_core/command/auditlog/disable.go
+++ b/core_components/bot_core/command/auditlog/disable.go
@@ -1,0 +1,89 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package auditlog
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api/slash_commands"
+)
+
+const (
+	disableCommandResponseHeader                      = "Disable Bot Audit Log"
+	disableAuditLogNeverConfiguredBeforeResponseName  = ":x: Oh no, no configuration could be found!"
+	disableAuditLogNeverConfiguredBeforeResponseValue = "The bot audit log is already disabled, as it has not been configured before!"
+	disableAuditLogAlreadyDisabledResponseName        = ":x: Nothing to do here!"
+	disableAuditLogAlreadyDisabledResponseValue       = "The bot audit log is already disabled!"
+	disableAuditSuccessResponseName                   = ":white_check_mark: Done!"
+	disableAuditLogSuccessResponseValue               = "The bot audit log is now disabled! You can enable it again at any time!"
+)
+
+func handleAuditLogDisable(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	_ *discordgo.ApplicationCommandInteractionDataOption,
+) {
+	resp := slash_commands.GenerateInteractionResponseTemplate(disableCommandResponseHeader, "")
+
+	guild, err := C.EntityManager().Guilds().Get(i.GuildID)
+	if nil != err {
+		slash_commands.RespondWithGenericErrorMessage(C, s, i, resp)
+
+		return
+	}
+
+	guildAuditLogConfig, err := C.EntityManager().AuditLogConfig().GetByGuildId(guild.ID)
+	if nil != err {
+		slash_commands.RespondWithSimpleEmbedMessage(C,
+			s,
+			i,
+			resp,
+			disableAuditLogNeverConfiguredBeforeResponseName,
+			disableAuditLogNeverConfiguredBeforeResponseValue)
+
+		return
+	}
+
+	if !guildAuditLogConfig.Enabled {
+		slash_commands.RespondWithSimpleEmbedMessage(C,
+			s,
+			i,
+			resp,
+			disableAuditLogAlreadyDisabledResponseName,
+			disableAuditLogAlreadyDisabledResponseValue)
+
+		return
+	}
+
+	guildAuditLogConfig.Enabled = false
+	guildAuditLogConfig.ChannelId = nil
+
+	err = C.EntityManager().AuditLogConfig().Save(guildAuditLogConfig)
+	if nil != err {
+		slash_commands.RespondWithGenericErrorMessage(C, s, i, resp)
+
+		return
+	}
+
+	slash_commands.RespondWithSimpleEmbedMessage(C,
+		s,
+		i,
+		resp,
+		disableAuditSuccessResponseName,
+		disableAuditLogSuccessResponseValue)
+}

--- a/core_components/bot_core/command/auditlog/enable.go
+++ b/core_components/bot_core/command/auditlog/enable.go
@@ -1,0 +1,156 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package auditlog
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api/slash_commands"
+	"strconv"
+)
+
+const (
+	enableCommandResponseHeader                            = "Enable Bot Audit Log"
+	enableCannotConfigureWithoutChannelResponseName        = ":x: Whoops, no bot audit log without a channel!"
+	enableCannotConfigureWithoutChannelResponseValue       = "To enable the bot audit log for the first time, you must enter a valid channel to write the logs to!"
+	enableAlreadyConfiguredForChannelResponseName          = ":x: Nothing to do here!"
+	enableAlreadyConfiguredForChannelResponseValueTemplate = "The bot audit log is already enabled and configured to use the channel %s!"
+	enableSuccessResponseName                              = ":white_check_mark: Done!"
+	enableSuccessResponseValueTemplate                     = "The bot audit log is now enabled and configured to use the channel %s!"
+)
+
+func handleAuditLogEnable(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	options *discordgo.ApplicationCommandInteractionDataOption,
+) {
+	resp := slash_commands.GenerateInteractionResponseTemplate(enableCommandResponseHeader, "")
+
+	guild, err := C.EntityManager().Guilds().Get(i.GuildID)
+	if nil != err {
+		slash_commands.RespondWithGenericErrorMessage(C, s, i, resp)
+
+		return
+	}
+
+	var channel *discordgo.Channel
+	for _, option := range options.Options {
+		if option.Name == "channel" {
+			channel = option.ChannelValue(s)
+
+			break
+		}
+	}
+
+	guildAuditLogConfig, err := C.EntityManager().AuditLogConfig().GetByGuildId(guild.ID)
+	if nil != err && nil == channel {
+		slash_commands.RespondWithSimpleEmbedMessage(C,
+			s,
+			i,
+			resp,
+			enableCannotConfigureWithoutChannelResponseName,
+			enableCannotConfigureWithoutChannelResponseValue)
+
+		return
+	}
+	if nil != err {
+		// Prepare new audit log config entity
+		guildAuditLogConfig.GuildID = guild.ID
+		guildAuditLogConfig.Guild = *guild
+	}
+
+	newChannelIdInt := uint64(0)
+	if nil != channel {
+		newChannelIdInt, err = strconv.ParseUint(channel.ID, 10, 64)
+		if nil != err {
+			slash_commands.RespondWithGenericErrorMessage(C, s, i, resp)
+
+			return
+		}
+	}
+
+	if guildAuditLogConfig.ChannelId != nil && *guildAuditLogConfig.ChannelId == newChannelIdInt && guildAuditLogConfig.Enabled {
+		slash_commands.RespondWithSimpleEmbedMessage(C,
+			s,
+			i,
+			resp,
+			enableAlreadyConfiguredForChannelResponseName,
+			fmt.Sprintf(enableAlreadyConfiguredForChannelResponseValueTemplate, channel.Mention()))
+
+		return
+	}
+
+	if nil != channel {
+		guildAuditLogConfig.ChannelId = &newChannelIdInt
+	}
+
+	if nil == guildAuditLogConfig.ChannelId && nil == channel {
+		slash_commands.RespondWithSimpleEmbedMessage(C,
+			s,
+			i,
+			resp,
+			enableCannotConfigureWithoutChannelResponseName,
+			enableCannotConfigureWithoutChannelResponseValue)
+
+		return
+	}
+
+	guildAuditLogConfig.Enabled = true
+
+	err = C.EntityManager().AuditLogConfig().Save(guildAuditLogConfig)
+	if nil != err {
+		slash_commands.RespondWithGenericErrorMessage(C, s, i, resp)
+
+		return
+	}
+
+	notifyAuditLogChannelConfigured(s, channel, i.Member)
+	slash_commands.RespondWithSimpleEmbedMessage(C,
+		s,
+		i,
+		resp,
+		enableSuccessResponseName,
+		fmt.Sprintf(enableSuccessResponseValueTemplate, channel.Mention()))
+}
+
+// notifyAuditLogChannelConfigured sends an information message to the channel that
+// has been configured as the new audit log channel.
+func notifyAuditLogChannelConfigured(session *discordgo.Session, channel *discordgo.Channel, member *discordgo.Member) {
+	if nil == member {
+		C.Logger().Warn("Failed to notify users on guild \"%s\" about bot audit log configuration "+
+			"with channel \"%s\" as member of interaction is nil!",
+			channel.GuildID,
+			channel.ID)
+	}
+
+	_, err := session.ChannelMessageSend(channel.ID, fmt.Sprintf(":white_check_mark: %s configured this "+
+		"channel to receive future bot audit log messages.\n\n"+
+		"If this channel was choosen by accident and you want to reconfigure the bot audit log, use the "+
+		"command `/jojo auditlog enable <channel>` to do so!\n"+
+		"If this action was unintended, use the command `/jojo auditlog disable` to disable the bot audit log.",
+		member.Mention()))
+
+	if nil != err {
+		C.Logger().Warn("Failed to notify users on guild \"%s\" about bot audit log configuration "+
+			"with channel \"%s\" triggered by user \"%s\"!",
+			channel.GuildID,
+			channel.ID,
+			member.User.ID)
+	}
+}

--- a/core_components/bot_core/command/auditlog/status.go
+++ b/core_components/bot_core/command/auditlog/status.go
@@ -1,0 +1,135 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package auditlog
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api/slash_commands"
+	"strconv"
+)
+
+// handleModuleDisable enables the targeted module.
+func handleAuditLogStatus(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	_ *discordgo.ApplicationCommandInteractionDataOption,
+) {
+	resp := slash_commands.GenerateInteractionResponseTemplate("Bot Audit Log", "")
+
+	guildIdInt, err := strconv.ParseUint(i.GuildID, 10, 64)
+	if nil != err {
+		respondWithError(s, i, resp)
+
+		return
+	}
+
+	guildAuditLogConfig, err := C.EntityManager().AuditLogConfig().GetByGuildId(guildIdInt)
+	if nil != err {
+		respondWithNotConfiguredStatus(s, i, resp)
+
+		return
+	}
+
+	populateAuditLogConfigStatusEmbedFields(resp,
+		getStatusDisplay(guildAuditLogConfig.Enabled),
+		getConfiguredChannel(s, guildAuditLogConfig.ChannelId),
+	)
+
+	slash_commands.Respond(C, s, i, resp)
+}
+
+// getStatusDisplay returns the string representation
+// of the passed audit log enablement status.
+func getStatusDisplay(auditLogEnabled bool) string {
+	if auditLogEnabled {
+		return ":white_check_mark:"
+	}
+
+	return ":x:"
+}
+
+// getConfiguredChannel returns the currently configured channel
+// for the bot audit log.
+func getConfiguredChannel(session *discordgo.Session, channel uint64) string {
+	channelIdStr := strconv.FormatUint(channel, 10)
+
+	dgChannel, err := session.Channel(channelIdStr)
+	if nil == err {
+		return fmt.Sprintf("<#%v>", dgChannel)
+	}
+
+	return "Not configured!"
+}
+
+// populateComponentStatusEmbedFields cares about filling up the interaction
+// response templates embed with the status of the requested component.
+func populateAuditLogConfigStatusEmbedFields(
+	resp *discordgo.InteractionResponseData,
+	auditLogStatus string,
+	auditLogChannel string,
+) {
+	resp.Embeds[0].Fields = []*discordgo.MessageEmbedField{
+		{
+			Name:   "Enabled",
+			Value:  auditLogStatus,
+			Inline: false,
+		},
+		{
+			Name:   "Configured Channel",
+			Value:  auditLogChannel,
+			Inline: false,
+		},
+	}
+}
+
+// respondWithNotConfiguredStatus responds with a message
+// telling the user that the audit log is not configured.
+//
+// This function should be used when no database row exists.
+func respondWithNotConfiguredStatus(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+) {
+	populateAuditLogConfigStatusEmbedFields(resp,
+		":x:",
+		"Not configured!")
+
+	slash_commands.Respond(C, s, i, resp)
+}
+
+// respondWithError responds with a message
+// telling the user the command failed.
+func respondWithError(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+) {
+	embeds := []*discordgo.MessageEmbedField{
+		{
+			Name:  ":x: Damn, something went wrong!",
+			Value: "Something unexpected happened while processing the command!",
+		},
+	}
+
+	resp.Embeds[0].Fields = embeds
+
+	slash_commands.Respond(C, s, i, resp)
+}

--- a/core_components/bot_core/command/auditlog/subcommand_handler.go
+++ b/core_components/bot_core/command/auditlog/subcommand_handler.go
@@ -21,6 +21,7 @@ package auditlog
 import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/lazybytez/jojo-discord-bot/api"
+	"github.com/lazybytez/jojo-discord-bot/api/slash_commands"
 )
 
 var C *api.Component
@@ -34,15 +35,20 @@ func HandleAuditLogCommandSubCommand(
 	i *discordgo.InteractionCreate,
 	option *discordgo.ApplicationCommandInteractionDataOption,
 ) {
+	if nil == i.Member {
+		slash_commands.RespondWithCommandIsGuildOnly(C, s, i, "auditlog")
+
+		return
+	}
+
 	subCommands := map[string]func(
 		s *discordgo.Session,
 		i *discordgo.InteractionCreate,
 		option *discordgo.ApplicationCommandInteractionDataOption,
 	){
-		"status": handleAuditLogStatus,
-		//"show":    handleModuleShow,
-		//"enable":  handleModuleEnable,
-		//"disable": handleModuleDisable,
+		"status":  handleAuditLogStatus,
+		"enable":  handleAuditLogEnable,
+		"disable": handleAuditLogDisable,
 	}
 
 	success := api.ProcessSubCommands(

--- a/core_components/bot_core/command/auditlog/subcommand_handler.go
+++ b/core_components/bot_core/command/auditlog/subcommand_handler.go
@@ -1,0 +1,64 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package auditlog
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api"
+)
+
+var C *api.Component
+
+// HandleAuditLogCommandSubCommand handles the execution of the
+// "auditlog" subcommand.
+//
+// The command allows to manage the bot audit log configuration.
+func HandleAuditLogCommandSubCommand(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	option *discordgo.ApplicationCommandInteractionDataOption,
+) {
+	subCommands := map[string]func(
+		s *discordgo.Session,
+		i *discordgo.InteractionCreate,
+		option *discordgo.ApplicationCommandInteractionDataOption,
+	){
+		"status": handleAuditLogStatus,
+		//"show":    handleModuleShow,
+		//"enable":  handleModuleEnable,
+		//"disable": handleModuleDisable,
+	}
+
+	success := api.ProcessSubCommands(
+		s,
+		i,
+		option,
+		subCommands)
+
+	if !success {
+		if !success {
+			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: "The executed (sub)command is invalid or does not exist!",
+				},
+			})
+		}
+	}
+}

--- a/core_components/bot_core/jojo_command.go
+++ b/core_components/bot_core/jojo_command.go
@@ -21,6 +21,7 @@ package bot_core
 import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/lazybytez/jojo-discord-bot/api"
+	"github.com/lazybytez/jojo-discord-bot/core_components/bot_core/command/auditlog"
 	"github.com/lazybytez/jojo-discord-bot/core_components/bot_core/command/module"
 	"github.com/lazybytez/jojo-discord-bot/core_components/bot_core/command/sync_commands"
 )
@@ -119,6 +120,41 @@ func initAndRegisterJojoCommand() {
 						"guild to tackle inconsistencies",
 					Type: discordgo.ApplicationCommandOptionSubCommand,
 				},
+				{
+					Name:        "auditlog",
+					Description: "Manage settings of the bot audit log!",
+					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Name:        "status",
+							Description: "Show the status of the current bot audit log configuration",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+						},
+						{
+							Name:        "enable",
+							Description: "Enable printing the bot audit log to the configured channel",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+						},
+						{
+							Name:        "disable",
+							Description: "Disable printing the bot audit log to the configured channel",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+						},
+						{
+							Name:        "set-channel",
+							Description: "Configure the channel where bot audit log messages should be send to",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Name:        "channel",
+									Description: "The channel where audit log messages should be send to",
+									Required:    true,
+									Type:        discordgo.ApplicationCommandOptionChannel,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		Handler: handleJojoCommand,
@@ -137,6 +173,7 @@ func handleJojoCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	){
 		"module":        module.HandleModuleSubCommand,
 		"sync-commands": sync_commands.HandleSyncCommandSubCommand,
+		"auditlog":      auditlog.HandleAuditLogCommandSubCommand,
 	}
 
 	api.ProcessSubCommands(

--- a/core_components/bot_core/jojo_command.go
+++ b/core_components/bot_core/jojo_command.go
@@ -29,6 +29,9 @@ import (
 // jojoCommand holds the command configuration for the jojo command.
 var jojoCommand *api.Command
 
+// adminMemberPermissions is the default permission used for the jojo command.
+var adminMemberPermissions int64 = discordgo.PermissionAdministrator
+
 // getModuleCommandChoices builds a slice containing all available modules
 // as command option choices
 func getModuleCommandChoices() []*discordgo.ApplicationCommandOptionChoice {
@@ -57,8 +60,9 @@ func initAndRegisterJojoCommand() {
 
 	jojoCommand = &api.Command{
 		Cmd: &discordgo.ApplicationCommand{
-			Name:        "jojo",
-			Description: "Manage modules and core settings of the bot!",
+			Name:                     "jojo",
+			Description:              "Manage modules and core settings of the bot!",
+			DefaultMemberPermissions: &adminMemberPermissions,
 			Options: []*discordgo.ApplicationCommandOption{
 				{
 					Name:        "module",
@@ -134,24 +138,22 @@ func initAndRegisterJojoCommand() {
 							Name:        "enable",
 							Description: "Enable printing the bot audit log to the configured channel",
 							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-						{
-							Name:        "disable",
-							Description: "Disable printing the bot audit log to the configured channel",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-						{
-							Name:        "set-channel",
-							Description: "Configure the channel where bot audit log messages should be send to",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
 							Options: []*discordgo.ApplicationCommandOption{
 								{
 									Name:        "channel",
 									Description: "The channel where audit log messages should be send to",
 									Required:    true,
 									Type:        discordgo.ApplicationCommandOptionChannel,
+									ChannelTypes: []discordgo.ChannelType{
+										discordgo.ChannelTypeGuildText,
+									},
 								},
 							},
+						},
+						{
+							Name:        "disable",
+							Description: "Disable printing the bot audit log to the configured channel",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
 						},
 					},
 				},


### PR DESCRIPTION
## Description
Add a bot audit log that allows to track any administrative actions done in context with the bots configuration and features.
This PR is part one of two, where part two will implement the bot audit log fucntionality itself.

## Related issue
Resolves #78 

## How can this be tested?
 - Check if `/jojo audit` and its subcommands full-fill their tasks
 - Check if the configured audit log channel receives audit log mesasges
 - Check if the database sucessfuly stores configuration and log data