### PR TITLE
Make messages from system commands ephemeral

### DIFF
--- a/core_components/bot_core/command/auditlog/disable.go
+++ b/core_components/bot_core/command/auditlog/disable.go
@@ -52,7 +52,7 @@ func handleAuditLogDisable(
 		user = i.Member.User
 	}
 
-	resp := slash_commands.GenerateInteractionResponseTemplate(disableCommandResponseHeader, "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate(disableCommandResponseHeader, "")
 
 	guild, err := C.EntityManager().Guilds().Get(i.GuildID)
 	if nil != err {

--- a/core_components/bot_core/command/auditlog/enable.go
+++ b/core_components/bot_core/command/auditlog/enable.go
@@ -54,7 +54,7 @@ func handleAuditLogEnable(
 		user = i.Member.User
 	}
 
-	resp := slash_commands.GenerateInteractionResponseTemplate(enableCommandResponseHeader, "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate(enableCommandResponseHeader, "")
 
 	guild, err := C.EntityManager().Guilds().Get(i.GuildID)
 	if nil != err {

--- a/core_components/bot_core/command/auditlog/status.go
+++ b/core_components/bot_core/command/auditlog/status.go
@@ -40,7 +40,7 @@ func handleAuditLogStatus(
 	i *discordgo.InteractionCreate,
 	_ *discordgo.ApplicationCommandInteractionDataOption,
 ) {
-	resp := slash_commands.GenerateInteractionResponseTemplate(statusCommandResponseHeader, "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate(statusCommandResponseHeader, "")
 
 	guild, err := C.EntityManager().Guilds().Get(i.GuildID)
 	if nil != err {

--- a/core_components/bot_core/command/module/disable.go
+++ b/core_components/bot_core/command/module/disable.go
@@ -31,7 +31,7 @@ func handleModuleDisable(
 	i *discordgo.InteractionCreate,
 	option *discordgo.ApplicationCommandInteractionDataOption,
 ) {
-	resp := slash_commands.GenerateInteractionResponseTemplate("Disable Module", "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate("Disable Module", "")
 
 	regComp := findComponent(option)
 	if nil == regComp || regComp.IsCoreComponent() {

--- a/core_components/bot_core/command/module/enable.go
+++ b/core_components/bot_core/command/module/enable.go
@@ -31,7 +31,7 @@ func handleModuleEnable(
 	i *discordgo.InteractionCreate,
 	option *discordgo.ApplicationCommandInteractionDataOption,
 ) {
-	resp := slash_commands.GenerateInteractionResponseTemplate("Enable Module", "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate("Enable Module", "")
 
 	regComp := findComponent(option)
 	if nil == regComp || regComp.IsCoreComponent() {

--- a/core_components/bot_core/command/module/list.go
+++ b/core_components/bot_core/command/module/list.go
@@ -42,7 +42,7 @@ func handleModuleList(
 // an embed that list all components and their status.
 // Additionally, a legend is added, that describes the meaning of the different states.
 func createComponentStatusListResponse(compNamesAndStatus string) *discordgo.InteractionResponseData {
-	resp := slash_commands.GenerateInteractionResponseTemplate(
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate(
 		"Module Status",
 		"Overview of all modules and whether they are enabled or not")
 

--- a/core_components/bot_core/command/module/show.go
+++ b/core_components/bot_core/command/module/show.go
@@ -30,7 +30,7 @@ func handleModuleShow(
 	i *discordgo.InteractionCreate,
 	option *discordgo.ApplicationCommandInteractionDataOption,
 ) {
-	resp := slash_commands.GenerateInteractionResponseTemplate("Module Information", "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate("Module Information", "")
 
 	regComp := findComponent(option)
 	if nil == regComp || regComp.IsCoreComponent() {

--- a/core_components/bot_core/command/sync_commands/subcommand_handler.go
+++ b/core_components/bot_core/command/sync_commands/subcommand_handler.go
@@ -59,7 +59,7 @@ func HandleSyncCommandSubCommand(
 		user = i.Member.User
 	}
 
-	resp := slash_commands.GenerateInteractionResponseTemplate("Slash Command Synchronisation", "")
+	resp := slash_commands.GenerateEphemeralInteractionResponseTemplate("Slash Command Synchronisation", "")
 
 	cacheKey := getLastGuildSyncCacheKey(i.GuildID)
 	lastSync, ok := cache.Get(cacheKey, time.Time{})


### PR DESCRIPTION
## Description
Make all responses from system commands ephemeral.
Most of those commands are logged in the audit log channel anyways (except for audit log commands themselves, but they are still recorded in database)

## Related issue
Resolves #67 

## How can this be tested?
 - Check all system commands if their responses are ephemeral
   - `/jojo module enable`
   - `/jojo module disable`
   - `/jojo module list`
   - `/jojo module show`
   - `/jojo auditlog enable`
   - `/jojo auditlog status`
   - `/jojo auditlog disable`
   - `/jojo sync-commands`