### PR TITLE
Better handle command sync on module toggle

### DIFF
--- a/core_components/bot_core/command/module/disable.go
+++ b/core_components/bot_core/command/module/disable.go
@@ -55,10 +55,14 @@ func handleModuleDisable(
 		return
 	}
 
+	respondWithTogglingComponent(
+		s,
+		i,
+		resp,
+		regComp.Name,
+		UserActionDisable)
 	C.SlashCommandManager().SyncApplicationComponentCommands(s, i.GuildID)
-
-	generateModuleDisableSuccessfulEmbedField(resp, regComp)
-	slash_commands.Respond(C, s, i, resp)
+	finishWithModuleDisableSuccessfulEmbedField(s, i, resp, regComp)
 
 	dgoGuild, err := s.Guild(i.GuildID)
 	if nil != err {
@@ -109,9 +113,12 @@ func disableComponentForGuild(
 	return true
 }
 
-// generateModuleDisableSuccessfulEmbedField creates the necessary embed fields
-// used to response to a successful module disable command.
-func generateModuleDisableSuccessfulEmbedField(
+// finishWithModuleDisableSuccessfulEmbedField updates the previously send
+// processing message with a success message, that indicates
+// that the module could be disabled properly.
+func finishWithModuleDisableSuccessfulEmbedField(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
 	resp *discordgo.InteractionResponseData,
 	comp *entities.RegisteredComponent,
 ) {
@@ -127,6 +134,10 @@ func generateModuleDisableSuccessfulEmbedField(
 			Inline: false,
 		},
 	}
+
+	slash_commands.EditResponse(C, s, i, &discordgo.WebhookEdit{
+		Embeds: &resp.Embeds,
+	})
 }
 
 // respondWithAlreadyDisabled fills the passed discordgo.InteractionResponseData

--- a/core_components/bot_core/command/module/disable.go
+++ b/core_components/bot_core/command/module/disable.go
@@ -49,6 +49,13 @@ func handleModuleDisable(
 		return
 	}
 
+	if isModuleToggleRateLimited(guild) {
+		respondWithRateLimited(s, i, resp)
+
+		return
+	}
+	increaseRateLimitCount(guild)
+
 	if !disableComponentForGuild(guild, regComp) {
 		respondWithAlreadyDisabled(s, i, resp, regComp.Name)
 

--- a/core_components/bot_core/command/module/enable.go
+++ b/core_components/bot_core/command/module/enable.go
@@ -47,6 +47,13 @@ func handleModuleEnable(
 		return
 	}
 
+	if isModuleToggleRateLimited(guild) {
+		respondWithRateLimited(s, i, resp)
+
+		return
+	}
+	increaseRateLimitCount(guild)
+
 	if !enableComponentForGuild(s, i, guild, regComp, resp) {
 		respondWithAlreadyEnabled(s, i, resp, regComp.Name)
 

--- a/core_components/bot_core/command/module/enable.go
+++ b/core_components/bot_core/command/module/enable.go
@@ -53,10 +53,14 @@ func handleModuleEnable(
 		return
 	}
 
+	respondWithTogglingComponent(
+		s,
+		i,
+		resp,
+		regComp.Name,
+		UserActionEnable)
 	C.SlashCommandManager().SyncApplicationComponentCommands(s, i.GuildID)
-
-	generateModuleEnableSuccessfulEmbedField(resp, regComp)
-	slash_commands.Respond(C, s, i, resp)
+	finishWithModuleEnableSuccessfulEmbedField(s, i, resp, regComp)
 
 	dgoGuild, err := s.Guild(i.GuildID)
 	if nil != err {
@@ -108,9 +112,6 @@ func enableComponentForGuild(
 			return false
 		}
 
-		generateModuleEnableSuccessfulEmbedField(resp, regComp)
-		slash_commands.Respond(C, s, i, resp)
-
 		return true
 	}
 
@@ -131,9 +132,12 @@ func enableComponentForGuild(
 	return true
 }
 
-// generateModuleEnableSuccessfulEmbedField creates the necessary embed fields
-// used to response to a successful module enable command.
-func generateModuleEnableSuccessfulEmbedField(
+// finishWithModuleEnableSuccessfulEmbedField updates the previously send
+// processing message with a success message, that indicates
+// that the module could be enabled properly.
+func finishWithModuleEnableSuccessfulEmbedField(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
 	resp *discordgo.InteractionResponseData,
 	comp *entities.RegisteredComponent,
 ) {
@@ -149,6 +153,10 @@ func generateModuleEnableSuccessfulEmbedField(
 			Inline: false,
 		},
 	}
+
+	slash_commands.EditResponse(C, s, i, &discordgo.WebhookEdit{
+		Embeds: &resp.Embeds,
+	})
 }
 
 // respondWithAlreadyEnabled fills the passed discordgo.InteractionResponseData

--- a/core_components/bot_core/command/module/rate_limiter.go
+++ b/core_components/bot_core/command/module/rate_limiter.go
@@ -1,0 +1,91 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package module
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api/entities"
+	"github.com/lazybytez/jojo-discord-bot/services/cache"
+)
+
+// ToggleModuleRateLimit is the maximum count how
+// often modules can be enabled and disabled in 10 minutes
+// before the user has to wait for the rate limit to expire.
+const ToggleModuleRateLimit = 10
+
+// getComponentToggleCountCacheKey returns the cache key used to store
+// the count of how often the module toggle commands were used in the last
+// 10 minutes.
+func getComponentToggleCountCacheKey(guildID uint64) string {
+	return fmt.Sprintf("component_toggle_counter_%d", guildID)
+}
+
+// isModuleToggleRateLimited returns whether the current guild is
+// right now rate limited or not.
+func isModuleToggleRateLimited(guild *entities.Guild) bool {
+	cacheKey := getComponentToggleCountCacheKey(guild.GuildID)
+	toggleCount, ok := cache.Get(cacheKey, 0)
+	if ok && toggleCount > ToggleModuleRateLimit {
+		return true
+	}
+
+	return false
+}
+
+// increaseRateLimitCount increases the count of module
+// toggles in the cache by one.
+// The function returns whether increasing the rate limit count
+// worked or not.
+func increaseRateLimitCount(guild *entities.Guild) bool {
+	cacheKey := getComponentToggleCountCacheKey(guild.GuildID)
+	toggleCount, ok := cache.Get(cacheKey, 0)
+	if !ok {
+		return false
+	}
+
+	toggleCount += 1
+	cache.Update(cacheKey, toggleCount)
+
+	return true
+}
+
+// respondWithRateLimited responds with a message telling the user that the has to wait
+// a few minutes before he uses the command again.
+func respondWithRateLimited(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+) {
+	embeds := []*discordgo.MessageEmbedField{
+		{
+			Name: ":x: Slow down my friend!",
+			Value: fmt.Sprintf("The `/jojo module enable` and `/jojo module disable` "+
+				"commands can only be used up to %d times in 10 minutes per guild!",
+				ToggleModuleRateLimit),
+		},
+	}
+
+	resp.Embeds[0].Fields = embeds
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: resp,
+	})
+}

--- a/core_components/bot_core/command/module/response.go
+++ b/core_components/bot_core/command/module/response.go
@@ -21,7 +21,44 @@ package module
 import (
 	"fmt"
 	"github.com/bwmarrin/discordgo"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lazybytez/jojo-discord-bot/api/slash_commands"
 )
+
+// UserAction is a string that can be output
+// to tell the user the action that is currently applied
+// to a module
+type UserAction string
+
+const (
+	UserActionEnable  = "enabled"
+	UserActionDisable = "disabled"
+)
+
+// respondWithTogglingComponent responds with a message
+// telling the user the command is still processing.
+// This is necessary as the module enable/disable process
+// can take a few seconds.
+func respondWithTogglingComponent(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	resp *discordgo.InteractionResponseData,
+	componentName string,
+	action UserAction,
+) {
+	embeds := []*discordgo.MessageEmbedField{
+		{
+			Name: ":alarm_clock: Processing...",
+			Value: spew.Sprintf("The module \"%s\" is being %s, please wait...",
+				componentName,
+				action),
+		},
+	}
+
+	resp.Embeds[0].Fields = embeds
+
+	slash_commands.Respond(C, s, i, resp)
+}
 
 // respondWithMissingComponent fills the passed discordgo.InteractionResponseData
 // with an embed field that indicates that the specified component could not be found.


### PR DESCRIPTION
## Description
 - Add processing message when toggling modules, to prevent timeout during long running command sync.
 - Rate limit the times the module toggle commands can be used in a specific time.

## Related issue
Improves #117 

## How can this be tested?
 - Check that the module enable and disable commands can only be used up to 10 times
 - Check that a temporary "Processing..." message is now printed when enabling or disabling modules