### PR TITLE
fix(api): add functionality to proper count guilds

### DIFF
--- a/api/component.go
+++ b/api/component.go
@@ -64,6 +64,7 @@ type Component struct {
 	// Their initialization happens through call to the methods
 	// used to get them (Example: logger -> Component.Logger()).
 	// See ServiceManager interface on how to obtain them.
+	discordApi          DiscordApiWrapper
 	logger              services.Logger
 	handlerManager      ComponentHandlerManager
 	slashCommandManager *SlashCommandManager

--- a/api/discordapi.go
+++ b/api/discordapi.go
@@ -1,0 +1,57 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+// DiscordGoApiWrapper is a wrapper around some crucial discordgo
+// functions. It provides functions that might be
+// frequently used without an ongoing event.
+type DiscordGoApiWrapper struct {
+	owner *Component
+}
+
+// DiscordApiWrapper provides some useful functions of the discord API,
+// that might be needed without an ongoing event.
+// An example would be the WebAPI.
+//
+// Also, the functions of this interface are sharding compatible.
+// As soon as sharding is enabled, functions like GuildCount will still
+// output the proper value.
+type DiscordApiWrapper interface {
+	// GuildCount returns the number of guilds the bot is currently on.
+	GuildCount() int
+}
+
+// DiscordApi is used to obtain the components slash DiscordApiWrapper management
+//
+// On first call, this function initializes the private Component.discordAPi
+// field. On consecutive calls, the already present DiscordGoApiWrapper will be used.
+func (c *Component) DiscordApi() DiscordApiWrapper {
+	if nil == c.discordApi {
+		c.discordApi = &DiscordGoApiWrapper{owner: c}
+	}
+
+	return c.discordApi
+}
+
+// GuildCount returns the number of guilds the bot is currently on.
+//
+// TODO: As soon as sharding support is implemented, the guild count needs to be computed from data collected across all shards
+func (dgw *DiscordGoApiWrapper) GuildCount() int {
+	return len(dgw.owner.discord.State.Guilds)
+}

--- a/components/statistics/collector.go
+++ b/components/statistics/collector.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	lastGuildCountUpdate    time.Time
-	cachedGuildCount        int64
+	cachedGuildCount        int
 	cachedSlashCommandCount = -1
 	cachedClusterId         string
 )
@@ -34,14 +34,10 @@ var (
 // or recomputes the guild count.
 //
 // The guild count is cached for 10 minutes.
-func collectGuildCount() int64 {
+func collectGuildCount() int {
 	if time.Since(lastGuildCountUpdate) > 10*time.Minute {
-		guildCount, err := C.EntityManager().Guilds().Count()
-		if nil != err {
-			guildCount = -1
-		}
+		cachedGuildCount = C.DiscordApi().GuildCount()
 
-		cachedGuildCount = guildCount
 		lastGuildCountUpdate = time.Now()
 	}
 

--- a/components/statistics/command.go
+++ b/components/statistics/command.go
@@ -27,7 +27,6 @@ import (
 	"github.com/lazybytez/jojo-discord-bot/build"
 	"io"
 	"runtime"
-	"strconv"
 	"text/tabwriter"
 	"time"
 )
@@ -117,7 +116,7 @@ func buildStatOutput() string {
 	buf := &bytes.Buffer{}
 
 	count := collectGuildCount()
-	countMsg := strconv.FormatInt(count, 10)
+	countMsg := fmt.Sprintf("%d", count)
 	if count == -1 {
 		countMsg = "Error"
 	}

--- a/components/statistics/webapi.go
+++ b/components/statistics/webapi.go
@@ -30,7 +30,7 @@ import (
 //
 // @Description Statistics holds statistics about the bot like the current version.
 type StatsDTO struct {
-	GuildCount        int64  `json:"guild_count"`
+	GuildCount        int    `json:"guild_count"`
 	SlashCommandCount int    `json:"slash_command_count"`
 	Version           string `json:"version"`
 } //@Name Statistics

--- a/internal/webapi.go
+++ b/internal/webapi.go
@@ -117,7 +117,7 @@ func initWebApi() {
 	v1ApiRouter = engine.Group(buildRoutePath(RouteApiV1))
 
 	httpServer = &http.Server{
-		Addr:    ":8080",
+		Addr:    Config.webApiBind,
 		Handler: engine,
 	}
 


### PR DESCRIPTION
## Description
Output the proper guild count in stats command and web api.
Note that as soon as shard support is implemented, this needs to be reworked, as it will only print out the current shards guild count then.

Additionally, this PR fixes the improper webserver binding, no matter what port has been specified in the environment.

## Related issue
Fixes #113 

## How can this be tested?
- Check that the guild count changes (at least every 10 minutes) when the bot leaves or joins guilds.