### PR TITLE
Add bot status management

### DIFF
--- a/api/component.go
+++ b/api/component.go
@@ -122,6 +122,17 @@ type ServiceManager interface {
 	// Prefer using the EntityManager instead, as DatabaseAccess is considered
 	// a low-level api.
 	DatabaseAccess() *EntityManager
+	// BotAuditLogger returns the bot audit logger for the current component,
+	// which allows to create audit log entries.
+	BotAuditLogger() *BotAuditLogger
+	// DiscordApi is used to obtain the components slash DiscordApiWrapper management
+	//
+	// On first call, this function initializes the private Component.discordAPi
+	// field. On consecutive calls, the already present DiscordGoApiWrapper will be used.
+	DiscordApi() DiscordApiWrapper
+	// BotStatusManager returns the current StatusManager which
+	// allows to add additional status to the bot.
+	BotStatusManager() StatusManager
 }
 
 // LoadComponent is used by the component registration system that

--- a/api/discordapi.go
+++ b/api/discordapi.go
@@ -18,6 +18,11 @@
 
 package api
 
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+)
+
 // DiscordGoApiWrapper is a wrapper around some crucial discordgo
 // functions. It provides functions that might be
 // frequently used without an ongoing event.
@@ -54,4 +59,29 @@ func (c *Component) DiscordApi() DiscordApiWrapper {
 // TODO: As soon as sharding support is implemented, the guild count needs to be computed from data collected across all shards
 func (dgw *DiscordGoApiWrapper) GuildCount() int {
 	return len(dgw.owner.discord.State.Guilds)
+}
+
+// SimpleBotStatus is a simplified version of discordgo.UpdateStatusData
+// that can be used to simply change the status of the bot to something else.
+// Note that the URL should be only set for discordgo.ActivityTypeStreaming.
+type SimpleBotStatus struct {
+	ActivityType discordgo.ActivityType
+	Content      string
+	Url          string
+}
+
+// SetBotStatus updates the status of the bot according to the passed
+// SimpleBotStatus data.
+func (dgw *DiscordGoApiWrapper) SetBotStatus(status SimpleBotStatus) error {
+	switch status.ActivityType {
+	case discordgo.ActivityTypeGame:
+		return dgw.owner.discord.UpdateGameStatus(0, status.Content)
+	case discordgo.ActivityTypeStreaming:
+		return dgw.owner.discord.UpdateStreamingStatus(0, status.Content, status.Url)
+	case discordgo.ActivityTypeListening:
+		return dgw.owner.discord.UpdateListeningStatus(status.Content)
+	default:
+		return fmt.Errorf("tried to update bot status to activity type \"%d\", which is not supported",
+			status.ActivityType)
+	}
 }

--- a/api/discordapi.go
+++ b/api/discordapi.go
@@ -40,6 +40,9 @@ type DiscordGoApiWrapper struct {
 type DiscordApiWrapper interface {
 	// GuildCount returns the number of guilds the bot is currently on.
 	GuildCount() int
+	// SetBotStatus updates the status of the bot according to the passed
+	// SimpleBotStatus data.
+	SetBotStatus(status SimpleBotStatus) error
 }
 
 // DiscordApi is used to obtain the components slash DiscordApiWrapper management

--- a/api/status.go
+++ b/api/status.go
@@ -1,0 +1,88 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+import (
+	"sync"
+)
+
+// botStatusManager is the DiscordGoStatusManager instance used across the bots' lifetime.
+var botStatusManager *DiscordGoStatusManager
+
+// DiscordGoStatusManager holds the available status of the bot
+// and manages the cycling of these.
+type DiscordGoStatusManager struct {
+	mu      sync.RWMutex
+	status  []SimpleBotStatus
+	current int
+}
+
+// StatusManager manages the available status
+// which are set fopr the bot.
+type StatusManager interface {
+	// AddStatusToRotation adds the given status to the list of
+	// rotated status.
+	AddStatusToRotation(status SimpleBotStatus)
+	// Next works like next on an iterator which self resets automatically.
+	Next() *SimpleBotStatus
+}
+
+// BotStatusManager returns the current StatusManager which
+// allows to add additional status to the bot.
+func (c *Component) BotStatusManager() StatusManager {
+	return botStatusManager
+}
+
+func init() {
+	botStatusManager = &DiscordGoStatusManager{
+		mu:      sync.RWMutex{},
+		status:  make([]SimpleBotStatus, 0),
+		current: 0,
+	}
+}
+
+// AddStatusToRotation adds the given status to the list of
+// rotated status.
+func (dgsm *DiscordGoStatusManager) AddStatusToRotation(status SimpleBotStatus) {
+	dgsm.mu.Lock()
+	defer dgsm.mu.Unlock()
+
+	dgsm.status = append(dgsm.status, status)
+}
+
+// Next works like next on an iterator which self resets automatically.
+func (dgsm *DiscordGoStatusManager) Next() *SimpleBotStatus {
+	dgsm.mu.Lock()
+	defer dgsm.mu.Unlock()
+
+	statusCount := len(dgsm.status)
+	if 0 == statusCount {
+		return nil
+	}
+
+	if dgsm.current >= statusCount {
+		dgsm.current = 0
+	}
+
+	status := &dgsm.status[dgsm.current]
+
+	dgsm.current = dgsm.current + 1
+
+	return status
+}

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,0 +1,100 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/suite"
+	"sync"
+	"testing"
+)
+
+type StatusManagerSuite struct {
+	suite.Suite
+}
+
+func (suite *StatusManagerSuite) SetupTest() {
+	botStatusManager = &DiscordGoStatusManager{
+		mu:      sync.RWMutex{},
+		status:  make([]SimpleBotStatus, 0),
+		current: 0,
+	}
+}
+
+func (suite *StatusManagerSuite) TestNextWithNoStatus() {
+	for i := 0; i < 10; i++ {
+		suite.Nil(botStatusManager.Next())
+	}
+}
+
+func (suite *StatusManagerSuite) TestNextWithOneStatus() {
+	firstStatus := SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeGame,
+		Content:      "Test",
+	}
+
+	botStatusManager.AddStatusToRotation(firstStatus)
+
+	// Cycle five times
+	for i := 0; i < 5; i++ {
+		suite.Equal(firstStatus, *botStatusManager.Next())
+	}
+}
+
+func (suite *StatusManagerSuite) TestNextWithMultipleStatus() {
+	firstStatus := SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeGame,
+		Content:      "Test",
+	}
+
+	secondStatus := SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeStreaming,
+		Url:          "https://localhost:8080/",
+	}
+
+	thirdStatus := SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeListening,
+		Content:      "Roundabout",
+	}
+
+	botStatusManager.AddStatusToRotation(firstStatus)
+	botStatusManager.AddStatusToRotation(secondStatus)
+	botStatusManager.AddStatusToRotation(thirdStatus)
+
+	// First cycle
+	suite.Equal(firstStatus, *botStatusManager.Next())
+	suite.Equal(secondStatus, *botStatusManager.Next())
+	suite.Equal(thirdStatus, *botStatusManager.Next())
+	// Second cycle
+	suite.Equal(firstStatus, *botStatusManager.Next())
+	suite.Equal(secondStatus, *botStatusManager.Next())
+	suite.Equal(thirdStatus, *botStatusManager.Next())
+	// Third cycle
+	suite.Equal(firstStatus, *botStatusManager.Next())
+	suite.Equal(secondStatus, *botStatusManager.Next())
+	suite.Equal(thirdStatus, *botStatusManager.Next())
+	// Fourth cycle
+	suite.Equal(firstStatus, *botStatusManager.Next())
+	suite.Equal(secondStatus, *botStatusManager.Next())
+	suite.Equal(thirdStatus, *botStatusManager.Next())
+}
+
+func TestStatusManager(t *testing.T) {
+	suite.Run(t, new(StatusManagerSuite))
+}

--- a/components/dice/register_command.go
+++ b/components/dice/register_command.go
@@ -28,5 +28,16 @@ func LoadComponent(_ *discordgo.Session) error {
 	// Register the messageCreate func as a callback for MessageCreate events.
 	_ = C.SlashCommandManager().Register(diceCommand)
 
+	registerBotStatus()
+
 	return nil
+}
+
+// registerBotStatus registers the bot status for status rotation
+// provided by the component.
+func registerBotStatus() {
+	C.BotStatusManager().AddStatusToRotation(api.SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeGame,
+		Content:      "/dice | throw dices",
+	})
 }

--- a/components/statistics/statistics.go
+++ b/components/statistics/statistics.go
@@ -45,7 +45,17 @@ func LoadComponent(_ *discordgo.Session) error {
 	_ = C.SlashCommandManager().Register(statsCommand)
 	_ = C.SlashCommandManager().Register(infoCommand)
 
+	registerBotStatus()
 	registerRoutes()
 
 	return nil
+}
+
+// registerBotStatus registers the bot status for status rotation
+// provided by the component.
+func registerBotStatus() {
+	C.BotStatusManager().AddStatusToRotation(api.SimpleBotStatus{
+		ActivityType: discordgo.ActivityTypeGame,
+		Content:      "/stats | bot insights",
+	})
 }

--- a/core_components/bot_status/bot_status.go
+++ b/core_components/bot_status/bot_status.go
@@ -85,6 +85,8 @@ func rotateStatus() {
 
 	if nil == status {
 		C.Logger().Info("Not updating status, as no status are registered!")
+
+		return
 	}
 
 	err := C.DiscordApi().SetBotStatus(*status)

--- a/core_components/bot_status/bot_status.go
+++ b/core_components/bot_status/bot_status.go
@@ -1,0 +1,102 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bot_status
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/lazybytez/jojo-discord-bot/api"
+	"time"
+)
+
+// BotStatusRotationTime is the time between the status
+// that are registered in the DiscordGoStatusManager.
+const BotStatusRotationTime = 5 * time.Minute
+
+var C = api.Component{
+	// Metadata
+	Code:         "bot_status",
+	Name:         "Bot Status",
+	Description:  "This component handles automated rotation and setting of the bot status in Discord.",
+	LoadPriority: -1000, // Be the last core component, so others can register initial status
+
+	State: &api.State{
+		DefaultEnabled: true,
+	},
+}
+
+// botStatusRotationTicker id the ticker used to periodically
+// change the bots' status.
+var botStatusRotationTicker *time.Ticker
+
+func init() {
+	api.RegisterComponent(&C, LoadComponent)
+}
+
+// LoadComponent loads the bot core component
+// and handles migration of core entities
+// and registration of important core event handlers.
+func LoadComponent(_ *discordgo.Session) error {
+	C.HandlerManager().RegisterOnce("start_status_rotation", onBotReady)
+
+	return nil
+}
+
+// onBotReady starts the bot status rotation.
+// At this point, discordgo is fully initialized and connected.
+func onBotReady(_ *discordgo.Session, _ *discordgo.Ready) {
+	startBotStatusRotation()
+}
+
+// startBotStatusRotation starts a routine that handles the automated rotation
+// of the bots' status.
+func startBotStatusRotation() {
+	botStatusRotationTicker = time.NewTicker(BotStatusRotationTime)
+
+	// Initial status rotation
+	rotateStatus()
+
+	// Continues status rotation
+	go func() {
+		for range botStatusRotationTicker.C {
+			rotateStatus()
+		}
+	}()
+}
+
+// rotateStatus updates the status of the bot by rotating it.
+func rotateStatus() {
+	status := C.BotStatusManager().Next()
+
+	if nil == status {
+		C.Logger().Info("Not updating status, as no status are registered!")
+	}
+
+	err := C.DiscordApi().SetBotStatus(*status)
+
+	if nil != err {
+		C.Logger().Err(err, "Could not update the status of the bot due to an unexpected error!")
+
+		return
+	}
+
+	C.Logger().Info("Updated bot status to content \"%s\" and url \"%s\" with activity type \"%d\"",
+		status.Content,
+		status.Url,
+		status.ActivityType)
+}

--- a/core_components/core_component_registry.go
+++ b/core_components/core_component_registry.go
@@ -21,5 +21,6 @@ package core_components
 import (
 	_ "github.com/lazybytez/jojo-discord-bot/core_components/bot_core"
 	_ "github.com/lazybytez/jojo-discord-bot/core_components/bot_log"
+	_ "github.com/lazybytez/jojo-discord-bot/core_components/bot_status"
 	_ "github.com/lazybytez/jojo-discord-bot/core_components/bot_webapi"
 )


### PR DESCRIPTION
## Description
Allow components to define custom status that the bot cycles through every few minutes.

## Related issue
Resolves #86 

## How can this be tested?
 - Check if the bot cycles through available status
