### PR TITLE
Add categories to commands and comps

### DIFF
--- a/api/categories.go
+++ b/api/categories.go
@@ -1,0 +1,33 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+// Category is used to categorize commands and components
+// into logical groups.
+type Category string
+
+// Categories holds a list of Categories
+type Categories []Category
+
+const (
+	CategoryInternal       = "Internal"
+	CategoryAdministration = "Administration"
+	CategoryFun            = "Fun"
+	CategoryUtilities      = "Utilities"
+)

--- a/api/component_test.go
+++ b/api/component_test.go
@@ -136,6 +136,73 @@ func (suite *ComponentTestSuite) TestIsCoreComponent() {
 	}
 }
 
+func (suite *ComponentTestSuite) TestComputeCategoriesWithOnlyInitialCategories() {
+	baseCategories := Categories{CategoryInternal}
+
+	testComponent := Component{
+		Code:       "some-component",
+		Categories: baseCategories,
+	}
+
+	suite.Equal(baseCategories, testComponent.Categories)
+}
+
+func (suite *ComponentTestSuite) TestComputeCategoriesWithOnlyCommandCategories() {
+	expectedResult := Categories{CategoryAdministration, CategoryUtilities}
+
+	testComponent := Component{
+		Code:       "some-component",
+		Categories: Categories{},
+	}
+
+	componentCommandMap = map[string]*Command{
+		"a": {
+			Category: CategoryAdministration,
+			c:        &testComponent,
+		},
+		"b": {
+			Category: CategoryUtilities,
+			c:        &testComponent,
+		},
+		"c": {
+			Category: CategoryAdministration,
+			c:        &testComponent,
+		},
+	}
+
+	testComponent.computeCategories()
+
+	suite.Equal(expectedResult, testComponent.Categories)
+}
+
+func (suite *ComponentTestSuite) TestComputeCategoriesWithMixedCategorySource() {
+	expectedResult := Categories{CategoryInternal, CategoryAdministration, CategoryUtilities}
+
+	testComponent := Component{
+		Code:       "some-component",
+		Categories: Categories{CategoryInternal},
+	}
+
+	componentCommandMap = map[string]*Command{
+		"a": {
+			Category: CategoryAdministration,
+			c:        &testComponent,
+		},
+		"b": {
+			Category: CategoryUtilities,
+			c:        &testComponent,
+		},
+		"c": {
+			Category: CategoryAdministration,
+			c:        &testComponent,
+		},
+	}
+
+	testComponent.computeCategories()
+
+	suite.Equal(expectedResult, testComponent.Categories)
+}
+
 func TestComponent(t *testing.T) {
 	suite.Run(t, new(ComponentTestSuite))
 }

--- a/api/slash_commands_test.go
+++ b/api/slash_commands_test.go
@@ -1,0 +1,96 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+import (
+	"github.com/lazybytez/jojo-discord-bot/api/entities"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type SlashCommandManagerTestSuite struct {
+	suite.Suite
+	owningComponent     *Component
+	slashCommandManager SlashCommandManager
+}
+
+func (suite *SlashCommandManagerTestSuite) SetupTest() {
+	suite.owningComponent = &Component{
+		Code: "test_component",
+		Name: "Test Component",
+	}
+	suite.slashCommandManager = SlashCommandManager{owner: suite.owningComponent}
+}
+
+func (suite *SlashCommandManagerTestSuite) TestGetCommandsForComponentWithoutMatchingCommands() {
+	testComponentCode := entities.ComponentCode("no_commands_component")
+	componentCommandMap = map[string]*Command{
+		"a": {
+			Category: CategoryAdministration,
+			c:        suite.owningComponent,
+		},
+		"b": {
+			Category: CategoryUtilities,
+			c:        suite.owningComponent,
+		},
+		"c": {
+			Category: CategoryAdministration,
+			c:        suite.owningComponent,
+		},
+	}
+
+	result := suite.slashCommandManager.GetCommandsForComponent(testComponentCode)
+
+	suite.Equal([]*Command{}, result)
+}
+
+func (suite *SlashCommandManagerTestSuite) TestGetCommandsForComponentWithCommands() {
+	testComponentCode := entities.ComponentCode("no_commands_component")
+
+	testComponent := &Component{
+		Code: testComponentCode,
+	}
+
+	foundCommandOne := &Command{
+		Category: CategoryAdministration,
+		c:        testComponent,
+	}
+	foundCommandTwo := &Command{
+		Category: CategoryUtilities,
+		c:        testComponent,
+	}
+
+	expectedResult := []*Command{foundCommandOne, foundCommandTwo}
+
+	componentCommandMap = map[string]*Command{
+		"a": foundCommandOne,
+		"c": {
+			Category: CategoryAdministration,
+			c:        suite.owningComponent,
+		},
+		"b": foundCommandTwo,
+	}
+
+	result := suite.slashCommandManager.GetCommandsForComponent(testComponentCode)
+	suite.Equal(expectedResult, result)
+}
+
+func TestSlashCommandManager(t *testing.T) {
+	suite.Run(t, new(SlashCommandManagerTestSuite))
+}

--- a/api/util/arrays.go
+++ b/api/util/arrays.go
@@ -16,37 +16,29 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package bot_webapi
+package util
 
-import (
-	"github.com/bwmarrin/discordgo"
-	"github.com/lazybytez/jojo-discord-bot/api"
-	"github.com/lazybytez/jojo-discord-bot/webapi"
-)
+// InArrayOrSlice checks if the provided element is in
+// the provided sliceOrArray.
+func InArrayOrSlice[T comparable](sliceOrArray []T, element T) bool {
+	for _, elem := range sliceOrArray {
+		if elem == element {
+			return true
+		}
+	}
 
-var C = api.Component{
-	// Metadata
-	Code:         "bot_webapi",
-	Name:         "Bot WebAPI",
-	Categories:   api.Categories{api.CategoryInternal},
-	Description:  "This component handles setup of the web api for the bots core api endpoints.",
-	LoadPriority: 999,
-
-	State: &api.State{
-		DefaultEnabled: true,
-	},
+	return false
 }
 
-func init() {
-	api.RegisterComponent(&C, LoadComponent)
-}
+// UniqueArrayOrSlice returns the passed slice or array without any duplicates in it.
+func UniqueArrayOrSlice[T comparable](sliceOrArray []T) []T {
+	unique := make([]T, 0)
 
-// LoadComponent loads the bot core component
-// and handles migration of core entities
-// and registration of important core event handlers.
-func LoadComponent(_ *discordgo.Session) error {
-	eg := webapi.Router().Group("/components")
-	eg.GET("/", ComponentsGet)
+	for _, elem := range sliceOrArray {
+		if !InArrayOrSlice(unique, elem) {
+			unique = append(unique, elem)
+		}
+	}
 
-	return nil
+	return unique
 }

--- a/api/util/arrays_test.go
+++ b/api/util/arrays_test.go
@@ -1,0 +1,76 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInArrayOrSlice(t *testing.T) {
+	tables := []struct {
+		arrayOrSlice []string
+		needle       string
+		result       bool
+	}{
+		{[]string{}, "test", false},
+		{[]string{"test"}, "test", true},
+		{[]string{"test", "other"}, "test", true},
+		{[]string{"other", "test"}, "test", true},
+		{[]string{"other", "with", "many", "test", "elements"}, "test", true},
+		{[]string{"other", "with", "many", "elements"}, "test", false},
+	}
+
+	for _, table := range tables {
+		result := InArrayOrSlice(table.arrayOrSlice, table.needle)
+
+		assert.Equalf(t,
+			table.result,
+			result,
+			"Failed to assert InArrayOrSlice with array \"%v\" and needle \"%s\"",
+			table.arrayOrSlice,
+			table.needle)
+	}
+}
+
+func TestUniqueArrayOrSlice(t *testing.T) {
+	tables := []struct {
+		arrayOrSlice []string
+		result       []string
+	}{
+		{[]string{}, []string{}},
+		{[]string{"test"}, []string{"test"}},
+		{[]string{"test", "test"}, []string{"test"}},
+		{[]string{"test", "other"}, []string{"test", "other"}},
+		{[]string{"test", "other", "test"}, []string{"test", "other"}},
+		{[]string{"test", "other", "test", "other"}, []string{"test", "other"}},
+		{[]string{"other", "with", "many", "test", "elements"}, []string{"other", "with", "many", "test", "elements"}},
+		{[]string{"other", "with", "test", "many", "test", "elements"}, []string{"other", "with", "test", "many", "elements"}},
+	}
+
+	for _, table := range tables {
+		result := UniqueArrayOrSlice(table.arrayOrSlice)
+
+		assert.Equalf(t,
+			table.result,
+			result,
+			"Failed to assert UniqueArrayOrSlice with array \"%v\"",
+			table.arrayOrSlice)
+	}
+}

--- a/components/dice/command.go
+++ b/components/dice/command.go
@@ -35,7 +35,8 @@ var diceCommand = &api.Command{
 			},
 		},
 	},
-	Handler: handleDice,
+	Category: api.CategoryFun,
+	Handler:  handleDice,
 }
 
 // handleDice handles the dice slash command

--- a/components/pingpong/command.go
+++ b/components/pingpong/command.go
@@ -28,7 +28,8 @@ var pingCommand = &api.Command{
 		Name:        "ping",
 		Description: "Play ping pong with the bot!",
 	},
-	Handler: handlePing,
+	Category: api.CategoryFun,
+	Handler:  handlePing,
 }
 
 func handlePing(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/components/statistics/command.go
+++ b/components/statistics/command.go
@@ -37,7 +37,8 @@ var statsCommand = &api.Command{
 		Name:        "stats",
 		Description: "Show information of the bot and runtime statistics.",
 	},
-	Handler: handleStats,
+	Category: api.CategoryUtilities,
+	Handler:  handleStats,
 }
 
 // infoCommand registers the alias /info

--- a/core_components/bot_core/bot_core.go
+++ b/core_components/bot_core/bot_core.go
@@ -27,6 +27,7 @@ var C = api.Component{
 	// Metadata
 	Code:         "bot_core",
 	Name:         "Bot Core",
+	Categories:   api.Categories{api.CategoryInternal},
 	Description:  "This component handles core routines and entity management.",
 	LoadPriority: 1000,
 

--- a/core_components/bot_core/jojo_command.go
+++ b/core_components/bot_core/jojo_command.go
@@ -160,7 +160,8 @@ func initAndRegisterJojoCommand() {
 				},
 			},
 		},
-		Handler: handleJojoCommand,
+		Category: api.CategoryAdministration,
+		Handler:  handleJojoCommand,
 	}
 
 	_ = C.SlashCommandManager().Register(jojoCommand)

--- a/core_components/bot_log/bot_log.go
+++ b/core_components/bot_log/bot_log.go
@@ -28,8 +28,9 @@ import (
 
 var C = api.Component{
 	// Metadata
-	Code: "bot_log",
-	Name: "Bot Log",
+	Code:       "bot_log",
+	Name:       "Bot Log",
+	Categories: api.Categories{api.CategoryInternal},
 	Description: "This component prints out some basic information in the " +
 		"log when bot is ready or added to guilds.",
 

--- a/core_components/bot_status/bot_status.go
+++ b/core_components/bot_status/bot_status.go
@@ -32,6 +32,7 @@ var C = api.Component{
 	// Metadata
 	Code:         "bot_status",
 	Name:         "Bot Status",
+	Categories:   api.Categories{api.CategoryInternal},
 	Description:  "This component handles automated rotation and setting of the bot status in Discord.",
 	LoadPriority: -1000, // Be the last core component, so others can register initial status
 

--- a/core_components/bot_webapi/components.go
+++ b/core_components/bot_webapi/components.go
@@ -37,6 +37,7 @@ import (
 type ComponentDTO struct {
 	Code          entities.ComponentCode `json:"code"`
 	Name          string                 `json:"name"`
+	Categories    api.Categories         `json:"categories"`
 	Description   string                 `json:"description"`
 	GlobalEnabled bool                   `json:"global_enabled"`
 	GuildEnabled  bool                   `json:"guild_enabled"`
@@ -72,6 +73,7 @@ func ComponentDTOFromComponent(c *api.Component, guildId string) (ComponentDTO, 
 	return ComponentDTO{
 		Code:          c.Code,
 		Name:          c.Name,
+		Categories:    c.Categories,
 		Description:   c.Description,
 		GlobalEnabled: gcs.Enabled,
 		GuildEnabled:  guildComponentStatus,


### PR DESCRIPTION
## Description
Implement posibility to add categories for commands and component.
This allows way better organization of our features.

## Related issue
Resolves #47 

## How can this be tested?
 - Check if swagger now shows categories for components