### PR TITLE
Add possibility for global commands

### DIFF
--- a/api/component_management.go
+++ b/api/component_management.go
@@ -88,6 +88,7 @@ func sortComponents() {
 
 // IsComponentEnabled checks if a specific component is currently enabled
 // for a specific guild.
+// If the guild id is empty, the function will return the global status of the component.
 func IsComponentEnabled(comp *Component, guildId string) bool {
 	if IsCoreComponent(comp) {
 		return true
@@ -105,10 +106,9 @@ func IsComponentEnabled(comp *Component, guildId string) bool {
 	}
 
 	if "" == guildId {
-		comp.Logger().Warn("Missing guild with ID \"%v\" in database!", guildId)
-
-		return false
+		return true
 	}
+
 	guild, err := em.Guilds().Get(guildId)
 	if nil != err {
 		comp.Logger().Warn("Missing guild with ID \"%v\" in database!", comp.Name)

--- a/api/slash_commands.go
+++ b/api/slash_commands.go
@@ -142,12 +142,12 @@ func handleCommandDispatch(s *discordgo.Session, i *discordgo.InteractionCreate)
 				if nil == err {
 					switch globalStatus.Enabled {
 					case true:
-						resp.Embeds[0].Fields[0].Value = fmt.Sprintf("The command `%s` is disabled on this "+
+						resp.Embeds[0].Fields[0].Value = fmt.Sprintf("The command `/%s` is disabled on this "+
 							"guild! Ask your guilds administrator to enable the `%s` component to use this command!",
 							command.Cmd.Name,
 							command.c.Name)
 					case false:
-						resp.Embeds[0].Fields[0].Value = fmt.Sprintf("The command `%s` is globally disabled. "+
+						resp.Embeds[0].Fields[0].Value = fmt.Sprintf("The command `/%s` is globally disabled. "+
 							"This might be due to some maintenance on the `%s` module.",
 							command.Cmd.Name,
 							command.c.Name)

--- a/api/slash_commands_global.go
+++ b/api/slash_commands_global.go
@@ -1,0 +1,55 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package api
+
+import "github.com/bwmarrin/discordgo"
+
+// SyncApplicationComponentGlobalCommands ensures that the available discordgo.ApplicationCommand
+// are synced for the given component globally.
+//
+// This means that disabled commands are enabled and enabled commands are disabled
+// depending on their global enable state.
+//
+// Also orphaned commands are cleaned up.
+// This is executed whenever a guild is joined or a component is toggled.
+//
+// Sync is a four-step process:
+//   - remove orphaned commands
+//   - remove disabled commands
+//   - add new commands
+//   - update existing commands
+func (c *SlashCommandManager) SyncApplicationComponentGlobalCommands(
+	session *discordgo.Session,
+) {
+	registeredCommands, err := session.ApplicationCommands(session.State.User.ID, "")
+	if nil != err {
+		slashCommandManagerLogger.Err(err, "Failed to handle global slash-command sync!")
+
+		return
+	}
+
+	slashCommandManagerLogger.Info("Syncing slash-commands globally...")
+	registeredCommands = c.removeOrphanedCommands(session, "", registeredCommands)
+	registeredCommands = c.removeCommandsByComponentState(session, "", registeredCommands)
+	registeredCommands = c.addCommandsByComponentState(session, "", registeredCommands)
+	_ = c.updateRegisteredCommands(session, "", registeredCommands)
+
+	slashCommandManagerLogger.Info(
+		"Finished syncing slash-commands globally...")
+}

--- a/api/slash_commands_test.go
+++ b/api/slash_commands_test.go
@@ -76,8 +76,6 @@ func (suite *SlashCommandManagerTestSuite) TestGetCommandsForComponentWithComman
 		c:        testComponent,
 	}
 
-	expectedResult := []*Command{foundCommandOne, foundCommandTwo}
-
 	componentCommandMap = map[string]*Command{
 		"a": foundCommandOne,
 		"c": {
@@ -88,7 +86,14 @@ func (suite *SlashCommandManagerTestSuite) TestGetCommandsForComponentWithComman
 	}
 
 	result := suite.slashCommandManager.GetCommandsForComponent(testComponentCode)
-	suite.Equal(expectedResult, result)
+
+	suite.Len(result, 2)
+
+	suite.Equal(foundCommandOne.c.Code, result[0].c.Code)
+	suite.Equal(foundCommandOne.Category, result[0].Category)
+
+	suite.Equal(foundCommandTwo.c.Code, result[1].c.Code)
+	suite.Equal(foundCommandTwo.Category, result[1].Category)
 }
 
 func TestSlashCommandManager(t *testing.T) {

--- a/api/util/comparator.go
+++ b/api/util/comparator.go
@@ -89,5 +89,9 @@ func PointerValuesEqual[T comparable](a *T, b *T) bool {
 		return true
 	}
 
+	if a == nil || b == nil {
+		return false
+	}
+
 	return *a == *b
 }

--- a/api/util/comparator.go
+++ b/api/util/comparator.go
@@ -81,3 +81,13 @@ func MapsEqual[K comparable, V comparable](a *map[K]V, b *map[K]V) bool {
 
 	return true
 }
+
+// PointerValuesEqual compares two comparable variables which values are pointers.
+// The function first checks for nil and then dereferences the pointers.
+func PointerValuesEqual[T comparable](a *T, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	return *a == *b
+}

--- a/api/util/comparator_test.go
+++ b/api/util/comparator_test.go
@@ -19,6 +19,7 @@
 package util
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
@@ -286,4 +287,37 @@ func (suite *MapsEqualTestSuite) TestMapsEqualEqualIntBoolean() {
 func TestComparator(t *testing.T) {
 	suite.Run(t, new(ArraysEqualTestSuite))
 	suite.Run(t, new(MapsEqualTestSuite))
+}
+
+func TestPointerValuesEqual(t *testing.T) {
+	stringA := "first string"
+	stringB := "second string"
+	stringC := "first string"
+
+	tables := []struct {
+		inputA         *string
+		inputB         *string
+		expectedResult bool
+	}{
+		{nil, nil, true},
+		{nil, &stringA, false},
+		{&stringA, nil, false},
+		{&stringA, &stringB, false},
+		{&stringB, &stringA, false},
+		{&stringA, &stringA, true},
+		{&stringA, &stringC, true},
+		{&stringC, &stringA, true},
+		{&stringC, &stringC, true},
+	}
+
+	for _, table := range tables {
+		result := PointerValuesEqual(table.inputA, table.inputB)
+
+		assert.Equalf(t,
+			table.expectedResult,
+			result,
+			"Arguments: %v, %v",
+			table.inputA,
+			table.inputB)
+	}
 }

--- a/components/dice/command.go
+++ b/components/dice/command.go
@@ -35,6 +35,7 @@ var diceCommand = &api.Command{
 			},
 		},
 	},
+	Global:   true,
 	Category: api.CategoryFun,
 	Handler:  handleDice,
 }

--- a/components/dice/register_command.go
+++ b/components/dice/register_command.go
@@ -10,7 +10,7 @@ import (
 var C = api.Component{
 	// Metadata
 	Code:        "dice",
-	Name:        "Dice Component",
+	Name:        "Dice",
 	Description: "This Component throws one or multiple dice",
 
 	State: &api.State{

--- a/components/pingpong/command.go
+++ b/components/pingpong/command.go
@@ -28,6 +28,7 @@ var pingCommand = &api.Command{
 		Name:        "ping",
 		Description: "Play ping pong with the bot!",
 	},
+	Global:   true,
 	Category: api.CategoryFun,
 	Handler:  handlePing,
 }
@@ -47,6 +48,7 @@ var pongCommand = &api.Command{
 		Name:        "pong",
 		Description: "Play ping pong with the bot!",
 	},
+	Global:  true,
 	Handler: handlePong,
 }
 

--- a/components/pingpong/command.go
+++ b/components/pingpong/command.go
@@ -28,7 +28,6 @@ var pingCommand = &api.Command{
 		Name:        "ping",
 		Description: "Play ping pong with the bot!",
 	},
-	Global:   true,
 	Category: api.CategoryFun,
 	Handler:  handlePing,
 }
@@ -48,7 +47,6 @@ var pongCommand = &api.Command{
 		Name:        "pong",
 		Description: "Play ping pong with the bot!",
 	},
-	Global:  true,
 	Handler: handlePong,
 }
 

--- a/components/statistics/command.go
+++ b/components/statistics/command.go
@@ -37,6 +37,7 @@ var statsCommand = &api.Command{
 		Name:        "stats",
 		Description: "Show information of the bot and runtime statistics.",
 	},
+	Global:   true,
 	Category: api.CategoryUtilities,
 	Handler:  handleStats,
 }
@@ -47,6 +48,7 @@ var infoCommand = &api.Command{
 		Name:        "info",
 		Description: "Show information of the bot and runtime statistics.",
 	},
+	Global:  true,
 	Handler: handleStats,
 }
 

--- a/components/statistics/statistics.go
+++ b/components/statistics/statistics.go
@@ -27,7 +27,7 @@ import (
 var C = api.Component{
 	// Metadata
 	Code:        "statistics",
-	Name:        "Statistics Component",
+	Name:        "Statistics",
 	Description: "This Component returns statistics about the bot and the runtime.",
 
 	State: &api.State{

--- a/core_components/bot_core/bot_core.go
+++ b/core_components/bot_core/bot_core.go
@@ -37,7 +37,6 @@ var C = api.Component{
 }
 
 func init() {
-
 	api.RegisterComponent(&C, LoadComponent)
 }
 
@@ -49,6 +48,7 @@ func LoadComponent(_ *discordgo.Session) error {
 
 	_, _ = C.HandlerManager().Register("guild_join", onGuildJoin)
 	_, _ = C.HandlerManager().Register("update_registered_guilds", handleGuildUpdateOnUpdate)
+	_, _ = C.HandlerManager().Register("update_global_commands", handleGlobalCommandSyncOnReady)
 
 	// We need to handle the JOJO command special as it needs access to the component list.
 	// This is only possible after the API has been properly initialized and the components.Components

--- a/core_components/bot_core/command/module/list.go
+++ b/core_components/bot_core/command/module/list.go
@@ -86,7 +86,7 @@ func generateComponentStatusTable(i *discordgo.InteractionCreate) string {
 		}
 
 		globalStatus, err := em.GlobalComponentStatus().GetDisplayString(regComp.ID)
-		if nil == err {
+		if nil == err && globalStatus != entities.GlobalComponentStatusEnabledDisplay {
 			getComponentStatusListRow(compNameAndStatus, regComp.Name, globalStatus)
 
 			continue

--- a/core_components/bot_core/command/module/list.go
+++ b/core_components/bot_core/command/module/list.go
@@ -86,7 +86,7 @@ func generateComponentStatusTable(i *discordgo.InteractionCreate) string {
 		}
 
 		globalStatus, err := em.GlobalComponentStatus().GetDisplayString(regComp.ID)
-		if nil != err {
+		if nil == err {
 			getComponentStatusListRow(compNameAndStatus, regComp.Name, globalStatus)
 
 			continue

--- a/core_components/bot_core/jojo_command.go
+++ b/core_components/bot_core/jojo_command.go
@@ -44,7 +44,7 @@ func getModuleCommandChoices() []*discordgo.ApplicationCommandOptionChoice {
 
 		availableModuleChoices = append(availableModuleChoices, &discordgo.ApplicationCommandOptionChoice{
 			Name:  comp.Name,
-			Value: comp.Code,
+			Value: string(comp.Code),
 		})
 	}
 

--- a/core_components/bot_core/slash_commands.go
+++ b/core_components/bot_core/slash_commands.go
@@ -1,0 +1,26 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bot_core
+
+import "github.com/bwmarrin/discordgo"
+
+// handleGlobalCommandSyncOnReady handles the one-time update of the global commands.
+func handleGlobalCommandSyncOnReady(session *discordgo.Session, _ *discordgo.Ready) {
+	C.SlashCommandManager().SyncApplicationComponentGlobalCommands(session)
+}


### PR DESCRIPTION
## Description
Make it possible to register commands globally.
This PR also makes the statistics and dice commands global.

## Related issue
Resolves #87 

## How can this be tested?
You must test the behaviour of components and commands depending on the component state (guild & global). Depending on the states, the commands must be available on guilds, globally or nowhere. 

Global commands:
 - stats / info
 - dice

Guild commands:
 - jojo
 - ping
 - pong

##### Test Cases
 - [x] Ensure the component `Dice` is enabled globally and on a guild.  Try to run the command on the guild. It should output a random number
 - [x] Ensure the component `Dice` is enabled globally and disabled on a guild.  Try to run the command on the guild. It should print a number
 - [x] Disable the `Ping Pong` component on a guild. The command should be no longer available
 - [x] Ensure that the `Statistics` component is enabled globally. Executing `/stats` in a DM should print the bot stats
 - [x] Ensure that the `Statistics` component is disabled globally. The `/stats` command should not be available anymore (if commands are not synced yet, executing the command should yield an error.
 - [x] In general, check all commands and components according to the other test cases. A list of components can be found above.