### PR TITLE
Keep empty docs module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ jojo-discord-bot
 go.work
 
 # Auto generated docs
-docs/
+docs/*
+!docs/keep.go
 
 # Development test database
 jojo.db

--- a/docs/keep.go
+++ b/docs/keep.go
@@ -1,0 +1,22 @@
+/*
+ * JOJO Discord Bot - An advanced multi-purpose discord bot
+ * Copyright (C) 2022 Lazy Bytez (Elias Knodel, Pascal Zarrad)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package docs
+
+// file to ensure module exists when installing/upgrading dependencies
+// without running `swag init`.


### PR DESCRIPTION
## Description
Keep the `docs` module with some placeholder file to allow renovate to update dependencies without previously running `swag init`.

## Related issue
#100 

## How can this be tested?
- Check after merge if renovate can now update dependencies